### PR TITLE
Develop app debug and repair tools

### DIFF
--- a/scripts/check-lint-config.py
+++ b/scripts/check-lint-config.py
@@ -13,7 +13,10 @@ from pathlib import Path
 class LintConfigChecker:
     def __init__(self, project_root):
         self.project_root = Path(project_root)
-        self.android_dir = self.project_root / "CleverFerret"
+        # Prefer standard module name `app`, fallback to legacy `CleverFerret`
+        candidate_app = self.project_root / "app"
+        candidate_cf = self.project_root / "CleverFerret"
+        self.android_dir = candidate_app if candidate_app.exists() else candidate_cf
         self.issues = []
         self.warnings = []
         

--- a/scripts/debug_app.sh
+++ b/scripts/debug_app.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Android app debug helper: builds, gathers errors, and runs analyzers
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Resolve module path (prefer :app if present, else :CleverFerret)
+MODULE_DIR="${PROJECT_ROOT}/app"
+if [[ ! -d "${MODULE_DIR}" ]]; then
+	MODULE_DIR="${PROJECT_ROOT}/CleverFerret"
+fi
+
+LOG_DIR="${PROJECT_ROOT}/debug-reports"
+mkdir -p "${LOG_DIR}"
+
+echo "🚀 Running debug build and analysis"
+echo "Project: ${PROJECT_ROOT}"
+echo "Module dir: ${MODULE_DIR}"
+echo "Reports: ${LOG_DIR}"
+
+cd "${PROJECT_ROOT}"
+
+# Ensure gradlew is executable if present
+if [[ -f "${PROJECT_ROOT}/gradlew" ]] && [[ ! -x "${PROJECT_ROOT}/gradlew" ]]; then
+	chmod +x "${PROJECT_ROOT}/gradlew"
+fi
+
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+BUILD_LOG="${LOG_DIR}/assembleDebug_${TIMESTAMP}.log"
+
+echo "🧹 Cleaning..."
+./gradlew clean --no-daemon --quiet || true
+
+echo "🔧 Attempting assembleDebug (this may fail, expected for triage)"
+set +e
+./gradlew :$(basename "${MODULE_DIR}"):assembleDebug --no-daemon --info --stacktrace 2>&1 | tee "${BUILD_LOG}"
+GRADLE_RC=${PIPESTATUS[0]}
+set -e
+
+echo "📄 Build log saved: ${BUILD_LOG}"
+
+# Extract Kotlin/Java compiler errors by file
+grep -E "^e: .*:(line|\d+:)" -n "${BUILD_LOG}" > "${LOG_DIR}/compiler_errors_${TIMESTAMP}.txt" || true
+
+# Count unique files with errors (Kotlin compiler style lines)
+ERROR_FILES_COUNT=$(grep -oE ":[0-9]+:" "${BUILD_LOG}" | wc -l | tr -d ' ')
+echo "📊 Approx error line occurrences: ${ERROR_FILES_COUNT}" | tee -a "${LOG_DIR}/summary_${TIMESTAMP}.txt"
+
+# Run auxiliary analyzers if available
+if [[ -f "${SCRIPT_DIR}/identify-compilation-errors.py" ]]; then
+	python3 "${SCRIPT_DIR}/identify-compilation-errors.py" "${PROJECT_ROOT}" | tee "${LOG_DIR}/static_compilation_scan_${TIMESTAMP}.txt" || true
+fi
+
+if [[ -f "${SCRIPT_DIR}/fix-dependencies.py" ]]; then
+	python3 "${SCRIPT_DIR}/fix-dependencies.py" "${PROJECT_ROOT}" | tee "${LOG_DIR}/dependency_scan_${TIMESTAMP}.txt" || true
+fi
+
+if [[ -f "${SCRIPT_DIR}/check-lint-config.py" ]]; then
+	python3 "${SCRIPT_DIR}/check-lint-config.py" "${PROJECT_ROOT}" | tee "${LOG_DIR}/lint_config_${TIMESTAMP}.txt" || true
+fi
+
+echo "✅ Debug helper complete. Review ${LOG_DIR} for artifacts."
+exit ${GRADLE_RC}
+

--- a/scripts/fix-dependencies.py
+++ b/scripts/fix-dependencies.py
@@ -11,7 +11,11 @@ from pathlib import Path
 class DependencyFixer:
     def __init__(self, project_root):
         self.project_root = Path(project_root)
-        self.build_file = self.project_root / "CleverFerret" / "build.gradle.kts"
+        # Detect Android module directory dynamically
+        candidate_app = self.project_root / "app"
+        candidate_cf = self.project_root / "CleverFerret"
+        self.module_dir = candidate_app if candidate_app.exists() else candidate_cf
+        self.build_file = self.module_dir / "build.gradle.kts"
         self.settings_file = self.project_root / "settings.gradle.kts"
         
     def analyze_dependencies(self):

--- a/scripts/identify-compilation-errors.py
+++ b/scripts/identify-compilation-errors.py
@@ -11,7 +11,10 @@ from pathlib import Path
 class CompilationErrorDetector:
     def __init__(self, project_root):
         self.project_root = Path(project_root)
-        self.android_dir = self.project_root / "CleverFerret"
+        # Prefer standard module name `app`, fallback to legacy `CleverFerret`
+        candidate_app = self.project_root / "app"
+        candidate_cf = self.project_root / "CleverFerret"
+        self.android_dir = candidate_app if candidate_app.exists() else candidate_cf
         self.source_dir = self.android_dir / "src/main/java/com/universalmedialibrary"
         self.errors = []
         self.warnings = []

--- a/scripts/repair_app.sh
+++ b/scripts/repair_app.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+
+# Android app repair orchestrator: dependency/lint checks, targeted builds, and report
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Resolve module path (prefer :app if present, else :CleverFerret)
+MODULE_DIR="${PROJECT_ROOT}/app"
+if [[ ! -d "${MODULE_DIR}" ]]; then
+	MODULE_DIR="${PROJECT_ROOT}/CleverFerret"
+fi
+
+REPORT_DIR="${PROJECT_ROOT}/repair-reports"
+mkdir -p "${REPORT_DIR}"
+TIMESTAMP=$(date +"%Y%m%d_%H%M%S")
+
+SUMMARY_FILE="${REPORT_DIR}/repair_summary_${TIMESTAMP}.md"
+
+echo "🔧 Starting repair orchestration"
+echo "Project: ${PROJECT_ROOT}"
+echo "Module dir: ${MODULE_DIR}"
+echo "Reports: ${REPORT_DIR}"
+
+cd "${PROJECT_ROOT}"
+
+# Ensure gradlew is executable if present
+if [[ -f "${PROJECT_ROOT}/gradlew" ]] && [[ ! -x "${PROJECT_ROOT}/gradlew" ]]; then
+	chmod +x "${PROJECT_ROOT}/gradlew"
+fi
+
+{
+echo "# Repair Orchestration Summary"
+echo "Generated: $(date)"
+echo
+} > "${SUMMARY_FILE}"
+
+DEP_STATUS=0
+LINT_STATUS=0
+ANALYSIS_STATUS=0
+BUILD_STATUS=0
+
+echo "📦 Analyzing/fixing dependencies..."
+if [[ -f "${SCRIPT_DIR}/fix-dependencies.py" ]]; then
+	set +e
+	python3 "${SCRIPT_DIR}/fix-dependencies.py" "${PROJECT_ROOT}" | tee "${REPORT_DIR}/dependencies_${TIMESTAMP}.txt"
+	DEP_STATUS=${PIPESTATUS[0]}
+	set -e
+else
+	echo "fix-dependencies.py not found" | tee -a "${SUMMARY_FILE}"
+fi
+
+echo "🧹 Checking lint configuration..."
+if [[ -f "${SCRIPT_DIR}/check-lint-config.py" ]]; then
+	set +e
+	python3 "${SCRIPT_DIR}/check-lint-config.py" "${PROJECT_ROOT}" | tee "${REPORT_DIR}/lint_config_${TIMESTAMP}.txt"
+	LINT_STATUS=${PIPESTATUS[0]}
+	set -e
+else
+	echo "check-lint-config.py not found" | tee -a "${SUMMARY_FILE}"
+fi
+
+echo "🔎 Static compilation scan..."
+if [[ -f "${SCRIPT_DIR}/identify-compilation-errors.py" ]]; then
+	set +e
+	python3 "${SCRIPT_DIR}/identify-compilation-errors.py" "${PROJECT_ROOT}" | tee "${REPORT_DIR}/static_compilation_scan_${TIMESTAMP}.txt"
+	ANALYSIS_STATUS=${PIPESTATUS[0]}
+	set -e
+fi
+
+echo "🧪 Running metadata check..."
+set +e
+./gradlew :$(basename "${MODULE_DIR}"):checkDebugAarMetadata --no-daemon --stacktrace 2>&1 | tee "${REPORT_DIR}/checkDebugAarMetadata_${TIMESTAMP}.log"
+META_RC=${PIPESTATUS[0]}
+set -e
+
+echo "🏗️ Attempting assembleDebug..."
+set +e
+./gradlew :$(basename "${MODULE_DIR}"):assembleDebug --no-daemon --info --stacktrace 2>&1 | tee "${REPORT_DIR}/assembleDebug_${TIMESTAMP}.log"
+BUILD_STATUS=${PIPESTATUS[0]}
+set -e
+
+ERR_FILE_COUNT=$(grep -oE ":[0-9]+:" "${REPORT_DIR}/assembleDebug_${TIMESTAMP}.log" | wc -l | tr -d ' ' || true)
+
+{
+echo "## Results"
+echo
+echo "- Dependency analysis exit code: ${DEP_STATUS}"
+echo "- Lint config check exit code: ${LINT_STATUS}"
+echo "- Static analysis exit code: ${ANALYSIS_STATUS}"
+echo "- checkDebugAarMetadata exit code: ${META_RC}"
+echo "- assembleDebug exit code: ${BUILD_STATUS}"
+echo "- Approx compiler error occurrences: ${ERR_FILE_COUNT}"
+echo
+echo "## Artifacts"
+echo
+echo "- Dependencies: repair-reports/dependencies_${TIMESTAMP}.txt"
+echo "- Lint config: repair-reports/lint_config_${TIMESTAMP}.txt"
+echo "- Static scan: repair-reports/static_compilation_scan_${TIMESTAMP}.txt"
+echo "- Metadata log: repair-reports/checkDebugAarMetadata_${TIMESTAMP}.log"
+echo "- Build log: repair-reports/assembleDebug_${TIMESTAMP}.log"
+} >> "${SUMMARY_FILE}"
+
+echo "✅ Repair orchestration complete. Summary: ${SUMMARY_FILE}"
+exit ${BUILD_STATUS}
+


### PR DESCRIPTION
Add `debug_app.sh` and `repair_app.sh` scripts to automate common debug and repair tasks for Android Gradle projects.

These scripts orchestrate builds, log collection, and static analysis, generating reports to aid in diagnosing and fixing application issues. Existing Python helper scripts were updated to dynamically detect the Android module (`app` or `CleverFerret`) for broader compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-3b21258b-7889-422d-8044-5e32e9eeaa6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3b21258b-7889-422d-8044-5e32e9eeaa6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

