### PR TITLE
Fix: Auto-detect Android SDK location for workspace environments

### DIFF
--- a/build-scripts/setup-build-environment.sh
+++ b/build-scripts/setup-build-environment.sh
@@ -13,32 +13,21 @@ export BUILD_TOOLS_VERSION="33.0.2"
 export COMPILE_SDK_VERSION="34"
 
 # Auto-detect Android SDK location
-SDK_CANDIDATE="${ANDROID_HOME:-}"
-for CAND in "$SDK_CANDIDATE" "/workspace/android-sdk" "$HOME/Android/Sdk"; do
-  [ -n "$CAND" ] && { [ -d "$CAND/platforms" ] || [ -d "$CAND/cmdline-tools" ] || [ -d "$CAND/platform-tools" ]; } && { ANDROID_HOME="$CAND"; ANDROID_SDK_ROOT="$CAND"; break; }
-done
-export ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}" ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
-[ -d "$ANDROID_HOME" ] || echo "Warning: Android SDK not found at expected locations; builds may fail."
-# Auto-detect Android SDK location
-SDK_CANDIDATE="${ANDROID_HOME:-}"
-[ -z "$SDK_CANDIDATE" ] && [ -d "/workspace/android-sdk" ] && SDK_CANDIDATE="/workspace/android-sdk"
-[ -z "$SDK_CANDIDATE" ] && [ -d "$HOME/Android/Sdk" ] && SDK_CANDIDATE="$HOME/Android/Sdk"
-if [ -n "$SDK_CANDIDATE" ] && ( [ -d "$SDK_CANDIDATE/platforms" ] || [ -d "$SDK_CANDIDATE/cmdline-tools" ] || [ -d "$SDK_CANDIDATE/platform-tools" ] ); then export ANDROID_HOME="$SDK_CANDIDATE"; export ANDROID_SDK_ROOT="$SDK_CANDIDATE"; else echo "Warning: Android SDK not found at expected locations; builds may fail."; export ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"; export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"; fi
-if [ -n "$SDK_CANDIDATE" ] && ( [ -d "$SDK_CANDIDATE/platforms" ] || [ -d "$SDK_CANDIDATE/cmdline-tools" ] || [ -d "$SDK_CANDIDATE/platform-tools" ] ); then export ANDROID_HOME="$SDK_CANDIDATE"; export ANDROID_SDK_ROOT="$SDK_CANDIDATE"; else echo "Warning: Android SDK not found at expected locations; builds may fail."; export ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"; export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"; fi
-    # Workspace/container environment
-    export ANDROID_HOME="${ANDROID_HOME:-/workspace/android-sdk}"
-SDK_CANDIDATE="${ANDROID_HOME:-}"
-[ -z "$SDK_CANDIDATE" ] && [ -d "/workspace/android-sdk" ] && SDK_CANDIDATE="/workspace/android-sdk"
-[ -z "$SDK_CANDIDATE" ] && [ -d "$HOME/Android/Sdk" ] && SDK_CANDIDATE="$HOME/Android/Sdk"
-if [ -n "$SDK_CANDIDATE" ] && ( [ -d "$SDK_CANDIDATE/platforms" ] || [ -d "$SDK_CANDIDATE/cmdline-tools" ] || [ -d "$SDK_CANDIDATE/platform-tools" ] ); then
-  export ANDROID_HOME="$SDK_CANDIDATE" ANDROID_SDK_ROOT="$SDK_CANDIDATE"
-else
-  export ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}" ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$HOME/Android/Sdk}"
-  echo "Warning: Android SDK not found at expected locations; builds may fail."
+# Priority: 1) Pre-set ANDROID_HOME, 2) Workspace/container, 3) Standard Android Studio
+if [ -z "$ANDROID_HOME" ]; then
+    if [ -d "/workspace/android-sdk" ]; then
+        # Workspace/container environment
+        export ANDROID_HOME="/workspace/android-sdk"
+    elif [ -d "$HOME/Android/Sdk" ]; then
+        # Standard Android Studio location
+        export ANDROID_HOME="$HOME/Android/Sdk"
+    else
+        # Fallback to default path to let the build system provide a clear error
+        export ANDROID_HOME="$HOME/Android/Sdk"
+    fi
 fi
-    # Standard Android Studio location
-    export ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"
-fi
+
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
 
 export JAVA_VERSION="17"
 

--- a/docs/APK_BUILD_FIX.md
+++ b/docs/APK_BUILD_FIX.md
@@ -23,10 +23,10 @@ sdk.dir=/workspace/android-sdk
 ```
 
 ### Automated Fix
-The `build-scripts/setup-build-environment.sh` script now auto-detects the Android SDK location:
-- In workspace/container environments: `/workspace/android-sdk`
-- In standard Android Studio environments: `$HOME/Android/Sdk`
-- Custom locations via `ANDROID_HOME` environment variable
+The `build-scripts/setup-build-environment.sh` script resolves the Android SDK location as follows:
+- If `ANDROID_HOME` is already set, it is respected and used as-is
+- Otherwise, in workspace/container environments: `/workspace/android-sdk`
+- Otherwise, default: `$HOME/Android/Sdk`
 
 ## Usage
 ### For Workspace/Container Environments
@@ -63,5 +63,6 @@ CleverFerret/build/outputs/apk/debug/CleverFerret-debug.apk
 
 ## Notes
 - `local.properties` is in `.gitignore` (as it should be) because it contains machine-specific paths
-- The setup script sets the `ANDROID_HOME` environment variable, which is an alternative to using `local.properties`.
+- The setup script sets the `ANDROID_HOME` environment variable when sourced, which is an alternative to using `local.properties`
+- A pre-existing `ANDROID_HOME` environment variable takes precedence over auto-detection
 - The fix ensures builds work in various environments without manual intervention


### PR DESCRIPTION
The APK build was failing with "SDK location not found" error because the build system couldn't locate the Android SDK. This happened when neither ANDROID_HOME environment variable nor local.properties file was configured.

Changes:
- Updated setup-build-environment.sh to auto-detect SDK location
- Added support for workspace/container environments (/workspace/android-sdk)
- Maintained backward compatibility with standard Android Studio paths
- Created documentation explaining the fix and usage

The setup script now automatically detects:
1. Workspace environment: /workspace/android-sdk
2. Standard Android Studio: $HOME/Android/Sdk
3. Custom via ANDROID_HOME environment variable

This ensures APK builds work across different environments without manual intervention.

Fixes the build error encountered in workspace environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented APK build failures by adding robust Android SDK auto-detection that checks workspace/container, standard Android Studio, and custom locations; sets ANDROID_HOME/ANDROID_SDK_ROOT when found and emits a clear warning with a safe fallback when not.

* **Documentation**
  * Added a step‑by‑step guide explaining the SDK location issue, manual and automated fixes for local, container, and CI/CD environments, verification steps, and expected APK output paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->