### PR TITLE
Fix vercel pwa build routes conflict

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,16 +10,6 @@
       }
     }
   ],
-  "routes": [
-    {
-      "src": "/pwa/(.*)",
-      "dest": "/pwa-demo/$1"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/pwa-demo/$1"
-    }
-  ],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Remove deprecated `routes` property from `vercel.json` to fix Vercel PWA build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4cdd369-16f6-40e1-b722-3ef905685ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4cdd369-16f6-40e1-b722-3ef905685ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment routing configuration by removing redundant direct route mappings and relying solely on existing rewrites. This streamlines the setup and reduces potential conflicts between routes and rewrites. No functional changes are expected—URLs and navigation should continue to work as before, including bookmarks and shared links. Please report any unexpected routing behavior encountered during navigation or deep-linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->