### PR TITLE
Fix plex issues in app

### DIFF
--- a/CleverFerret/src/main/java/com/universalmedialibrary/services/plex/PlexAuthApi.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/services/plex/PlexAuthApi.kt
@@ -56,6 +56,20 @@ interface PlexAuthApi {
         @Query("includeRelay") includeRelay: Int = 0,
         @Query("includeIPv6") includeIPv6: Int = 0
     ): Response<List<PlexResourceResponse>>
+
+    /**
+     * Sign in using Plex username/password credentials
+     * POST https://plex.tv/users/sign_in.json
+     *
+     * Returns user object containing authentication token
+     */
+    @FormUrlEncoded
+    @POST("/users/sign_in.json")
+    suspend fun signInWithCredentials(
+        @Field("user[login]") username: String,
+        @Field("user[password]") password: String,
+        @Field("user[remember_me]") rememberMe: Int = 1
+    ): Response<PlexUserResponse>
 }
 
 /**

--- a/CleverFerret/src/main/java/com/universalmedialibrary/services/plex/PlexAuthService.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/services/plex/PlexAuthService.kt
@@ -171,6 +171,66 @@ class PlexAuthService @Inject constructor(
     }
 
     /**
+     * Authenticate directly with Plex username/password credentials.
+     * Stores the returned token on success.
+     */
+    suspend fun authenticateWithCredentials(
+        username: String,
+        password: String
+    ): Result<PlexAuthResult> {
+        return try {
+            if (username.isBlank() || password.isBlank()) {
+                val message = "Username and password are required"
+                _authState.value = PlexAuthState.Error(message)
+                return Result.failure(IllegalArgumentException(message))
+            }
+
+            _authState.value = PlexAuthState.FetchingUserInfo
+
+            val response = authApi.signInWithCredentials(username, password)
+            if (!response.isSuccessful || response.body() == null) {
+                val error = when (response.code()) {
+                    401 -> "Invalid Plex credentials"
+                    else -> "Failed to sign in: ${response.code()} ${response.message()}"
+                }
+                Log.e(TAG, error)
+                _authState.value = PlexAuthState.Error(error)
+                return Result.failure(Exception(error))
+            }
+
+            val user = response.body()!!
+            val token = user.authToken
+            if (token.isNullOrEmpty()) {
+                val error = "Plex authentication succeeded but no token was returned"
+                Log.e(TAG, error)
+                _authState.value = PlexAuthState.Error(error)
+                return Result.failure(IllegalStateException(error))
+            }
+
+            tokenStorage.saveAuthToken(
+                token = token,
+                userId = user.id.toString(),
+                username = user.username
+            )
+
+            val authResult = PlexAuthResult(
+                token = token,
+                userId = user.id.toString(),
+                username = user.username,
+                email = user.email,
+                thumb = user.thumb
+            )
+
+            _authState.value = PlexAuthState.Authenticated(authResult)
+            Result.success(authResult)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error signing in with credentials", e)
+            _authState.value = PlexAuthState.Error(e.message ?: "Unknown error")
+            Result.failure(e)
+        }
+    }
+
+    /**
      * Discover available Plex servers for the authenticated user
      *
      * Uses GET /api/v2/resources to find all owned and shared servers
@@ -236,6 +296,15 @@ class PlexAuthService @Inject constructor(
     }
 
     /**
+     * Clear any error state and revert to idle
+     */
+    fun clearError() {
+        if (_authState.value is PlexAuthState.Error) {
+            _authState.value = PlexAuthState.Idle
+        }
+    }
+
+    /**
      * Check if user is currently authenticated
      */
     fun isAuthenticated(): Boolean {
@@ -247,6 +316,13 @@ class PlexAuthService @Inject constructor(
      */
     fun getStoredToken(): String? {
         return tokenStorage.getAuthToken()
+    }
+
+    /**
+     * Get stored username if available
+     */
+    fun getStoredUsername(): String? {
+        return tokenStorage.getUsername()
     }
 }
 

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/plex/PlexAuthViewModel.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/plex/PlexAuthViewModel.kt
@@ -149,15 +149,41 @@ class PlexAuthViewModel @Inject constructor(
      * Get stored username
      */
     fun getUsername(): String? {
-        return authService.getStoredToken()?.let {
-            // In a real implementation, we'd decode the token or fetch from storage
-            "Plex User"
-        }
+        return authService.getStoredUsername() ?: authService.getStoredToken()?.let { "Plex User" }
     }
 
     override fun onCleared() {
         super.onCleared()
         pollingJob?.cancel()
+    }
+
+    /**
+     * Clear current error state if present
+     */
+    fun clearError() {
+        authService.clearError()
+        if (_authState.value is PlexAuthUiState.Error) {
+            _authState.value = PlexAuthUiState.Idle
+        }
+    }
+
+    /**
+     * Sign in using credentials (username/password) instead of PIN.
+     */
+    fun signInWithCredentials(username: String, password: String) {
+        val trimmedUsername = username.trim()
+        if (trimmedUsername.isEmpty() || password.isEmpty()) {
+            _authState.value = PlexAuthUiState.Error("Please enter both username and password")
+            return
+        }
+
+        viewModelScope.launch {
+            val result = authService.authenticateWithCredentials(trimmedUsername, password)
+            result.onSuccess {
+                // Automatically fetch available servers after successful sign-in
+                discoverServers()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### **User description**
Add Plex username/password authentication to fix sign-in issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-840609ba-3aaf-4596-863d-7cc8df54cfb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-840609ba-3aaf-4596-863d-7cc8df54cfb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds username/password authentication support for Plex to address sign-in issues in the app. It introduces a new API endpoint for credential-based authentication (`signInWithCredentials`), implements the authentication flow in the service layer with proper token storage, and exposes the functionality through the ViewModel. The changes also include helper methods for error handling (`clearError`) and retrieving stored usernames, enabling users to authenticate via credentials as an alternative to the existing PIN-based flow.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/src/main/java/com/universalmedialibrary/services/plex/PlexAuthApi.kt` |
| 2 | `CleverFerret/src/main/java/com/universalmedialibrary/services/plex/PlexAuthService.kt` |
| 3 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/plex/PlexAuthViewModel.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add Plex username/password credential-based authentication endpoint

- Implement credential authentication flow with token storage

- Expose credential sign-in functionality through ViewModel

- Add helper methods for error clearing and username retrieval


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User Credentials"] -->|signInWithCredentials| B["PlexAuthApi"]
  B -->|POST /users/sign_in.json| C["Plex Server"]
  C -->|PlexUserResponse| D["PlexAuthService"]
  D -->|Store Token| E["TokenStorage"]
  D -->|Update State| F["PlexAuthViewModel"]
  F -->|Display Result| G["UI"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PlexAuthApi.kt</strong><dd><code>Add credential-based sign-in API endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/services/plex/PlexAuthApi.kt

<ul><li>Added new <code>signInWithCredentials</code> API endpoint for form-encoded POST <br>request<br> <li> Endpoint targets <code>/users/sign_in.json</code> with username, password, and <br>remember_me fields<br> <li> Returns <code>PlexUserResponse</code> containing authentication token</ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/385/files#diff-80a8821021eb7be4c1600bd3a6a9b27e61e2637195800dce05cc34a265ccca6d">+14/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PlexAuthService.kt</strong><dd><code>Implement credential authentication and helper methods</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/services/plex/PlexAuthService.kt

<ul><li>Implemented <code>authenticateWithCredentials</code> method with input validation <br>and error handling<br> <li> Stores authentication token and user info on successful credential <br>authentication<br> <li> Added <code>clearError</code> method to reset error state to idle<br> <li> Added <code>getStoredUsername</code> method to retrieve stored username from token <br>storage</ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/385/files#diff-94b161827e8d7b816382cfe6e2ede9248a887534a4e6c1a69bfac0efa450f155">+76/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PlexAuthViewModel.kt</strong><dd><code>Add credential sign-in and error clearing to ViewModel</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/ui/plex/PlexAuthViewModel.kt

<ul><li>Updated <code>getUsername</code> to use <code>getStoredUsername</code> from service for accurate <br>retrieval<br> <li> Added <code>clearError</code> method to clear error UI state<br> <li> Implemented <code>signInWithCredentials</code> method with input validation and <br>automatic server discovery<br> <li> Launches credential authentication in viewModelScope with success <br>callback</ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/385/files#diff-5fd8e3075ac30640cd8dd9a6e5f39c05426a00e9becc1c1ad4953a4762afc247">+30/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added username and password-based authentication for Plex sign-in, providing users with an additional sign-in method.
  * Added error clearing functionality to resolve authentication error states.
  * Enhanced username storage and retrieval for improved account recognition during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->