### PR TITLE
Fix player access on wrong thread

### DIFF
--- a/CleverFerret/src/main/java/com/universalmedialibrary/services/audio/AudioPlaybackManager.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/services/audio/AudioPlaybackManager.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import com.universalmedialibrary.services.media.MediaNotificationService
 import com.universalmedialibrary.services.media.MediaSessionManager
 import javax.inject.Inject
@@ -132,12 +133,14 @@ class AudioPlaybackManager @Inject constructor(
         scrobblerScope.launch {
             audioPreferences.preferences.collect { prefs ->
                 cachedPreferences = prefs
-                applySkipSilence(prefs.skipSilence, persist = false)
-                applyCrossfade(
-                    enabled = prefs.crossfadeEnabled,
-                    durationMs = prefs.crossfadeDurationMs,
-                    persist = false
-                )
+                withContext(Dispatchers.Main.immediate) {
+                    applySkipSilence(prefs.skipSilence, persist = false)
+                    applyCrossfade(
+                        enabled = prefs.crossfadeEnabled,
+                        durationMs = prefs.crossfadeDurationMs,
+                        persist = false
+                    )
+                }
                 updateState(lastSleepTimerMinutes = prefs.lastSleepTimerMinutes)
             }
         }
@@ -271,9 +274,11 @@ class AudioPlaybackManager @Inject constructor(
                     delay(minOf(SLEEP_TIMER_TICK_MS, remaining))
                     remaining = endTime - System.currentTimeMillis()
                 }
-                finalizeHistoryCandidate()
-                exoPlayer.pause()
-                updateState(sleepTimerEndTime = null, sleepTimerUpdated = true)
+                withContext(Dispatchers.Main.immediate) {
+                    finalizeHistoryCandidate()
+                    exoPlayer.pause()
+                    updateState(sleepTimerEndTime = null, sleepTimerUpdated = true)
+                }
             } finally {
                 sleepTimerJob = null
             }


### PR DESCRIPTION
### **User description**
Dispatch ExoPlayer operations to the main thread to prevent `IllegalStateException`.

The `IllegalStateException` occurred because ExoPlayer was accessed from a background thread. This PR ensures that calls to `applySkipSilence`, `applyCrossfade`, and `exoPlayer.pause()` originating from background coroutines (specifically, preference collection and sleep timer completion) are executed on the main thread.

---
<a href="https://cursor.com/background-agent?bcId=bc-db8792d2-5591-4e55-8bcc-f42a197d1414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db8792d2-5591-4e55-8bcc-f42a197d1414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal threading operations for audio playback management to improve performance and responsiveness. No user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes an `IllegalStateException` caused by accessing ExoPlayer from background threads. The fix wraps ExoPlayer operations (`applySkipSilence`, `applyCrossfade`, and `exoPlayer.pause()`) with `withContext(Dispatchers.Main.immediate)` to ensure they execute on the main thread. The threading issues occurred in two scenarios: when collecting audio preference changes and when the sleep timer completes.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/src/main/java/com/universalmedialibrary/services/audio/AudioPlaybackManager.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->


___

### **PR Type**
Bug fix


___

### **Description**
- Wrap ExoPlayer operations with `withContext(Dispatchers.Main.immediate)` to prevent `IllegalStateException`

- Dispatch preference collection callbacks to main thread

- Dispatch sleep timer completion operations to main thread

- Add `withContext` import from kotlinx.coroutines


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Background Coroutines"] -->|"withContext Main.immediate"| B["Main Thread"]
  B --> C["ExoPlayer Operations"]
  B --> D["State Updates"]
  A1["Preference Collection"] -->|"dispatch"| B
  A2["Sleep Timer Completion"] -->|"dispatch"| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AudioPlaybackManager.kt</strong><dd><code>Dispatch ExoPlayer operations to main thread</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/services/audio/AudioPlaybackManager.kt

<ul><li>Added <code>withContext</code> import from kotlinx.coroutines<br> <li> Wrapped <code>applySkipSilence</code> and <code>applyCrossfade</code> calls in preference <br>collection with <code>withContext(Dispatchers.Main.immediate)</code><br> <li> Wrapped <code>finalizeHistoryCandidate</code>, <code>exoPlayer.pause()</code>, and <code>updateState</code> <br>calls in sleep timer completion with <br><code>withContext(Dispatchers.Main.immediate)</code><br> <li> Ensures all ExoPlayer operations execute on main thread to prevent <br>threading violations</ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/417/files#diff-5cba73b4af4fd7cf0352ad52b3b09879f3cb4a39fa8d8c8b6f5f42d05bb25ff5">+14/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

