### PR TITLE
Debug and fix build failures

### DIFF
--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/settings/SettingsViewModel.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/settings/SettingsViewModel.kt
@@ -70,24 +70,8 @@ class SettingsViewModel @Inject constructor(
                 settingsRepository.bottomGearPositionFlow,
                 settingsRepository.miniPlayerBackgroundModeFlow,
                 settingsRepository.bottomBarPreferencesFlow
-            ) { theme,
-                darkMode,
-                autoDownload,
-                wifiOnly,
-                notificationsEnabled,
-                bottomGear,
-                backgroundMode,
-                bottomBarPrefs ->
-                SettingsUiState(
-                    selectedTheme = theme,
-                    darkMode = darkMode,
-                    autoDownloadPodcasts = autoDownload,
-                    wifiOnlyDownloads = wifiOnly,
-                    notificationsEnabled = notificationsEnabled,
-                    bottomGearPosition = bottomGear,
-                    miniPlayerBackgroundMode = backgroundMode,
-                    bottomBarPreferences = bottomBarPrefs
-                )
+            ) { values: Array<Any?> ->
+                createSettingsUiState(values)
             }.collect { newState ->
                 _uiState.value = newState
             }
@@ -335,6 +319,29 @@ class SettingsViewModel @Inject constructor(
         skipOutroSeconds = skipOutroSeconds, // Now using the actual field from GeneralSettings
         lastUpdated = System.currentTimeMillis()
     )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun createSettingsUiState(values: Array<Any?>): SettingsUiState {
+        val theme = values[0] as ThemePalette
+        val darkMode = values[1] as Boolean
+        val autoDownload = values[2] as Boolean
+        val wifiOnly = values[3] as Boolean
+        val notificationsEnabled = values[4] as Boolean
+        val bottomGear = values[5] as BottomGearPosition
+        val backgroundMode = values[6] as MiniPlayerBackgroundMode
+        val bottomBarPrefs = values[7] as BottomBarPreferences
+
+        return SettingsUiState(
+            selectedTheme = theme,
+            darkMode = darkMode,
+            autoDownloadPodcasts = autoDownload,
+            wifiOnlyDownloads = wifiOnly,
+            notificationsEnabled = notificationsEnabled,
+            bottomGearPosition = bottomGear,
+            miniPlayerBackgroundMode = backgroundMode,
+            bottomBarPreferences = bottomBarPrefs
+        )
+    }
 }
 
 data class SettingsUiState(


### PR DESCRIPTION
### **User description**
Update `SettingsViewModel` to correctly use the `combine` API, resolving a signature mismatch and centralizing UI state creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae5c57c0-68d4-49b5-85c6-54a135caf1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ae5c57c0-68d4-49b5-85c6-54a135caf1f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a build failure in `SettingsViewModel` by refactoring the `combine` API usage. The inline lambda that was directly destructuring 8 Flow parameters into a `SettingsUiState` object has been replaced with a lambda accepting an `Array<Any?>`, which is then processed by a new helper method `createSettingsUiState`. This change resolves a signature mismatch issue while maintaining the same functionality for combining multiple settings flows into a single UI state.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/settings/SettingsViewModel.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->


___

### **PR Type**
Bug fix


___

### **Description**
- Refactor `combine` API usage to fix signature mismatch

- Replace inline destructuring lambda with `Array<Any?>` parameter

- Extract UI state creation into new `createSettingsUiState` helper method

- Maintain identical functionality while resolving build failure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["combine 8 Flows"] -- "Array&lt;Any?&gt;" --> B["createSettingsUiState"]
  B -- "SettingsUiState" --> C["collect & update"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SettingsViewModel.kt</strong><dd><code>Extract combine lambda into helper method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/ui/settings/SettingsViewModel.kt

<ul><li>Replaced inline lambda with 8 destructured parameters with <code>Array<Any?></code> <br>parameter in <code>combine</code> call<br> <li> Extracted UI state creation logic into new private helper method <br><code>createSettingsUiState</code><br> <li> Added type casting and <code>@Suppress("UNCHECKED_CAST")</code> annotation for safe <br>array element casting<br> <li> Preserved all original field mappings and functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/423/files#diff-9de57e6d8b2f17b4435ecaa85aec28843b7b1646273a9c5c110e515dcb23e761">+25/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal code optimizations with no visible changes to end-user functionality. All existing features and behaviors remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->