### PR TITLE
Diagnose theme and api settings issues

### DIFF
--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/CleverFerretTheme.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/CleverFerretTheme.kt
@@ -28,11 +28,17 @@ val LocalMetallicGradient = staticCompositionLocalOf { MetallicEffects.Gold }
 private fun getMetallicEffectForTheme(palette: ThemePalette): MetallicGradient {
     return when (palette) {
         ThemePalette.NAVY_GOLD -> MetallicEffects.Gold
+        ThemePalette.EMERALD_SILVER -> MetallicEffects.Silver
+        ThemePalette.ROYAL_BRONZE -> MetallicEffects.Copper
+        ThemePalette.MIDNIGHT_AMBER -> MetallicEffects.Gold
+        ThemePalette.OBSIDIAN_CRIMSON -> MetallicEffects.Copper
+        ThemePalette.SLATE_CYAN -> MetallicEffects.Gunmetal
         ThemePalette.ROYAL_SILVER -> MetallicEffects.Silver
         ThemePalette.FOREST_COPPER -> MetallicEffects.Copper
         ThemePalette.BURGUNDY_ROSE_GOLD -> MetallicEffects.RoseGold
         ThemePalette.CHARCOAL_CHAMPAGNE -> MetallicEffects.Champagne
         ThemePalette.SLATE_GUNMETAL -> MetallicEffects.Gunmetal
+        ThemePalette.DEEP_PURPLE_PLATINUM -> MetallicEffects.Silver
         ThemePalette.COPPER_BRONZE -> MetallicEffects.Copper
         ThemePalette.AMBER_GOLD -> MetallicEffects.Gold
         ThemePalette.ROSE_BRASS -> MetallicEffects.RoseGold
@@ -55,11 +61,17 @@ fun CleverFerretTheme(
     // Map old enum to new unified theme system
     val theme = when (palette) {
         ThemePalette.NAVY_GOLD -> CleverFerretTheme.NAVY_GOLD
+        ThemePalette.EMERALD_SILVER -> CleverFerretTheme.EMERALD_SILVER
+        ThemePalette.ROYAL_BRONZE -> CleverFerretTheme.ROYAL_BRONZE
+        ThemePalette.MIDNIGHT_AMBER -> CleverFerretTheme.MIDNIGHT_AMBER
+        ThemePalette.OBSIDIAN_CRIMSON -> CleverFerretTheme.OBSIDIAN_CRIMSON
+        ThemePalette.SLATE_CYAN -> CleverFerretTheme.SLATE_CYAN
         ThemePalette.ROYAL_SILVER -> CleverFerretTheme.ROYAL_SILVER
         ThemePalette.FOREST_COPPER -> CleverFerretTheme.FOREST_COPPER
         ThemePalette.BURGUNDY_ROSE_GOLD -> CleverFerretTheme.BURGUNDY_ROSE_GOLD
         ThemePalette.CHARCOAL_CHAMPAGNE -> CleverFerretTheme.CHARCOAL_CHAMPAGNE
         ThemePalette.SLATE_GUNMETAL -> CleverFerretTheme.SLATE_GUNMETAL
+        ThemePalette.DEEP_PURPLE_PLATINUM -> CleverFerretTheme.DEEP_PURPLE_PLATINUM
         ThemePalette.COPPER_BRONZE -> CleverFerretTheme.COPPER_BRONZE
         ThemePalette.AMBER_GOLD -> CleverFerretTheme.AMBER_GOLD
         ThemePalette.ROSE_BRASS -> CleverFerretTheme.ROSE_BRASS

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ColorPalettes.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ColorPalettes.kt
@@ -417,12 +417,19 @@ object SlateGunmetalPalette {
 
 // Theme palette enum for selection
 enum class ThemePalette {
+    // Unified cross-platform themes
     NAVY_GOLD,
+    EMERALD_SILVER,
+    ROYAL_BRONZE,
+    MIDNIGHT_AMBER,
+    OBSIDIAN_CRIMSON,
+    SLATE_CYAN,
     ROYAL_SILVER,
     FOREST_COPPER,
     BURGUNDY_ROSE_GOLD,
     CHARCOAL_CHAMPAGNE,
     SLATE_GUNMETAL,
+    DEEP_PURPLE_PLATINUM,
     // Warm Metallic Themes
     COPPER_BRONZE,
     AMBER_GOLD,
@@ -440,11 +447,17 @@ enum class ThemePalette {
     fun toCleverFerretTheme(): com.universalmedialibrary.ui.theme.CleverFerretTheme {
         return when (this) {
             NAVY_GOLD -> com.universalmedialibrary.ui.theme.CleverFerretTheme.NAVY_GOLD
+            EMERALD_SILVER -> com.universalmedialibrary.ui.theme.CleverFerretTheme.EMERALD_SILVER
+            ROYAL_BRONZE -> com.universalmedialibrary.ui.theme.CleverFerretTheme.ROYAL_BRONZE
+            MIDNIGHT_AMBER -> com.universalmedialibrary.ui.theme.CleverFerretTheme.MIDNIGHT_AMBER
+            OBSIDIAN_CRIMSON -> com.universalmedialibrary.ui.theme.CleverFerretTheme.OBSIDIAN_CRIMSON
+            SLATE_CYAN -> com.universalmedialibrary.ui.theme.CleverFerretTheme.SLATE_CYAN
             ROYAL_SILVER -> com.universalmedialibrary.ui.theme.CleverFerretTheme.ROYAL_SILVER
             FOREST_COPPER -> com.universalmedialibrary.ui.theme.CleverFerretTheme.FOREST_COPPER
             BURGUNDY_ROSE_GOLD -> com.universalmedialibrary.ui.theme.CleverFerretTheme.BURGUNDY_ROSE_GOLD
             CHARCOAL_CHAMPAGNE -> com.universalmedialibrary.ui.theme.CleverFerretTheme.CHARCOAL_CHAMPAGNE
             SLATE_GUNMETAL -> com.universalmedialibrary.ui.theme.CleverFerretTheme.SLATE_GUNMETAL
+            DEEP_PURPLE_PLATINUM -> com.universalmedialibrary.ui.theme.CleverFerretTheme.DEEP_PURPLE_PLATINUM
             COPPER_BRONZE -> com.universalmedialibrary.ui.theme.CleverFerretTheme.COPPER_BRONZE
             AMBER_GOLD -> com.universalmedialibrary.ui.theme.CleverFerretTheme.AMBER_GOLD
             ROSE_BRASS -> com.universalmedialibrary.ui.theme.CleverFerretTheme.ROSE_BRASS

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ThemeMigration.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ThemeMigration.kt
@@ -12,11 +12,17 @@ package com.universalmedialibrary.ui.theme
 fun ThemePalette.toCleverFerretTheme(): CleverFerretTheme {
     return when (this) {
         ThemePalette.NAVY_GOLD -> CleverFerretTheme.NAVY_GOLD
+        ThemePalette.EMERALD_SILVER -> CleverFerretTheme.EMERALD_SILVER
+        ThemePalette.ROYAL_BRONZE -> CleverFerretTheme.ROYAL_BRONZE
+        ThemePalette.MIDNIGHT_AMBER -> CleverFerretTheme.MIDNIGHT_AMBER
+        ThemePalette.OBSIDIAN_CRIMSON -> CleverFerretTheme.OBSIDIAN_CRIMSON
+        ThemePalette.SLATE_CYAN -> CleverFerretTheme.SLATE_CYAN
         ThemePalette.ROYAL_SILVER -> CleverFerretTheme.ROYAL_SILVER
         ThemePalette.FOREST_COPPER -> CleverFerretTheme.FOREST_COPPER
         ThemePalette.BURGUNDY_ROSE_GOLD -> CleverFerretTheme.BURGUNDY_ROSE_GOLD
         ThemePalette.CHARCOAL_CHAMPAGNE -> CleverFerretTheme.CHARCOAL_CHAMPAGNE
         ThemePalette.SLATE_GUNMETAL -> CleverFerretTheme.SLATE_GUNMETAL
+        ThemePalette.DEEP_PURPLE_PLATINUM -> CleverFerretTheme.DEEP_PURPLE_PLATINUM
         ThemePalette.COPPER_BRONZE -> CleverFerretTheme.COPPER_BRONZE
         ThemePalette.AMBER_GOLD -> CleverFerretTheme.AMBER_GOLD
         ThemePalette.ROSE_BRASS -> CleverFerretTheme.ROSE_BRASS

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ThemePreviewScreen.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ThemePreviewScreen.kt
@@ -362,11 +362,17 @@ private fun PaletteSelectorDialog(
 
 private fun getThemeDescription(palette: ThemePalette): String = when (palette) {
     ThemePalette.NAVY_GOLD -> "Navy + Metallic Gold • Elegant"
+    ThemePalette.EMERALD_SILVER -> "Emerald Green + Silver • Nature Inspired"
+    ThemePalette.ROYAL_BRONZE -> "Royal Purple + Bronze • Regal"
+    ThemePalette.MIDNIGHT_AMBER -> "Midnight Blue + Amber • Night Mode"
+    ThemePalette.OBSIDIAN_CRIMSON -> "Obsidian Black + Crimson • Dramatic"
+    ThemePalette.SLATE_CYAN -> "Slate Grey + Cyan • Futuristic"
     ThemePalette.ROYAL_SILVER -> "Royal Purple + Silver • Regal"
     ThemePalette.FOREST_COPPER -> "Forest Green + Copper • Natural"
     ThemePalette.BURGUNDY_ROSE_GOLD -> "Burgundy + Rose Gold • Luxurious"
     ThemePalette.CHARCOAL_CHAMPAGNE -> "Charcoal + Champagne • Sophisticated"
     ThemePalette.SLATE_GUNMETAL -> "Slate + Gunmetal • Modern"
+    ThemePalette.DEEP_PURPLE_PLATINUM -> "Deep Purple + Platinum • Premium"
     ThemePalette.COPPER_BRONZE -> "Copper + Bronze • Warm & Rich"
     ThemePalette.AMBER_GOLD -> "Amber + Gold • Luminous"
     ThemePalette.ROSE_BRASS -> "Rose + Brass • Romantic"

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/UnifiedThemeSystem.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/UnifiedThemeSystem.kt
@@ -409,11 +409,17 @@ fun CleverFerretTheme.isAncientArchitect(): Boolean {
 fun CleverFerretTheme.toThemePalette(): com.universalmedialibrary.ui.theme.ThemePalette {
     return when (this) {
         CleverFerretTheme.NAVY_GOLD -> com.universalmedialibrary.ui.theme.ThemePalette.NAVY_GOLD
+        CleverFerretTheme.EMERALD_SILVER -> com.universalmedialibrary.ui.theme.ThemePalette.EMERALD_SILVER
+        CleverFerretTheme.ROYAL_BRONZE -> com.universalmedialibrary.ui.theme.ThemePalette.ROYAL_BRONZE
+        CleverFerretTheme.MIDNIGHT_AMBER -> com.universalmedialibrary.ui.theme.ThemePalette.MIDNIGHT_AMBER
+        CleverFerretTheme.OBSIDIAN_CRIMSON -> com.universalmedialibrary.ui.theme.ThemePalette.OBSIDIAN_CRIMSON
+        CleverFerretTheme.SLATE_CYAN -> com.universalmedialibrary.ui.theme.ThemePalette.SLATE_CYAN
         CleverFerretTheme.ROYAL_SILVER -> com.universalmedialibrary.ui.theme.ThemePalette.ROYAL_SILVER
         CleverFerretTheme.FOREST_COPPER -> com.universalmedialibrary.ui.theme.ThemePalette.FOREST_COPPER
         CleverFerretTheme.BURGUNDY_ROSE_GOLD -> com.universalmedialibrary.ui.theme.ThemePalette.BURGUNDY_ROSE_GOLD
         CleverFerretTheme.CHARCOAL_CHAMPAGNE -> com.universalmedialibrary.ui.theme.ThemePalette.CHARCOAL_CHAMPAGNE
         CleverFerretTheme.SLATE_GUNMETAL -> com.universalmedialibrary.ui.theme.ThemePalette.SLATE_GUNMETAL
+        CleverFerretTheme.DEEP_PURPLE_PLATINUM -> com.universalmedialibrary.ui.theme.ThemePalette.DEEP_PURPLE_PLATINUM
         CleverFerretTheme.COPPER_BRONZE -> com.universalmedialibrary.ui.theme.ThemePalette.COPPER_BRONZE
         CleverFerretTheme.AMBER_GOLD -> com.universalmedialibrary.ui.theme.ThemePalette.AMBER_GOLD
         CleverFerretTheme.ROSE_BRASS -> com.universalmedialibrary.ui.theme.ThemePalette.ROSE_BRASS
@@ -423,13 +429,6 @@ fun CleverFerretTheme.toThemePalette(): com.universalmedialibrary.ui.theme.Theme
         CleverFerretTheme.ANCIENT_BRONZE -> com.universalmedialibrary.ui.theme.ThemePalette.ANCIENT_BRONZE
         CleverFerretTheme.SILVER_ARCHITECT -> com.universalmedialibrary.ui.theme.ThemePalette.SILVER_ARCHITECT
         CleverFerretTheme.OBSIDIAN_TECH -> com.universalmedialibrary.ui.theme.ThemePalette.OBSIDIAN_TECH
-        // Themes not in ThemePalette fall back to NAVY_GOLD
-        CleverFerretTheme.EMERALD_SILVER,
-        CleverFerretTheme.ROYAL_BRONZE,
-        CleverFerretTheme.MIDNIGHT_AMBER,
-        CleverFerretTheme.OBSIDIAN_CRIMSON,
-        CleverFerretTheme.SLATE_CYAN,
-        CleverFerretTheme.DEEP_PURPLE_PLATINUM -> com.universalmedialibrary.ui.theme.ThemePalette.NAVY_GOLD
     }
 }
 


### PR DESCRIPTION
### **User description**
Add support for six new theme palettes to fix the "Select Theme" picker not persisting choices.

---
<a href="https://cursor.com/background-agent?bcId=bc-962d3b9e-de42-4e81-92ef-9f4313eab40f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-962d3b9e-de42-4e81-92ef-9f4313eab40f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where the theme picker wasn't persisting user selections by adding six new theme palettes (`EMERALD_SILVER`, `ROYAL_BRONZE`, `MIDNIGHT_AMBER`, `OBSIDIAN_CRIMSON`, `SLATE_CYAN`, and `DEEP_PURPLE_PLATINUM`) to the `ThemePalette` enum. Previously, these themes existed in the `CleverFerretTheme` system but were falling back to `NAVY_GOLD` when converting between theme representations, causing selected themes to not persist correctly. The changes add proper mappings for these themes across all conversion functions and UI components.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ColorPalettes.kt` |
| 2 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/UnifiedThemeSystem.kt` |
| 3 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ThemeMigration.kt` |
| 4 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/CleverFerretTheme.kt` |
| 5 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ThemePreviewScreen.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added six new color theme palettes: Emerald Silver, Royal Bronze, Midnight Amber, Obsidian Crimson, Slate Cyan, and Deep Purple Platinum, providing enhanced visual customization options.
  * Expanded metallic accent effects across all theme selections for improved aesthetic variety.
  * Ensured full end-to-end support for all new color schemes throughout the theming system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add six new theme palettes to `ThemePalette` enum for proper persistence

- Map new themes across all conversion functions and UI components

- Assign appropriate metallic effects to each new theme palette

- Remove fallback behavior that was causing theme selection loss


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ThemePalette Enum"] -->|"Add 6 new themes"| B["EMERALD_SILVER, ROYAL_BRONZE, MIDNIGHT_AMBER, OBSIDIAN_CRIMSON, SLATE_CYAN, DEEP_PURPLE_PLATINUM"]
  B -->|"Map to CleverFerretTheme"| C["CleverFerretTheme.kt"]
  B -->|"Map in conversion functions"| D["UnifiedThemeSystem.kt & ThemeMigration.kt"]
  B -->|"Assign metallic effects"| E["getMetallicEffectForTheme"]
  B -->|"Add UI descriptions"| F["ThemePreviewScreen.kt"]
  C -->|"Enables theme persistence"| G["Theme Selection Works"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ColorPalettes.kt</strong><dd><code>Add new theme palette enum values and mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ColorPalettes.kt

<ul><li>Add six new theme palette enum values to <code>ThemePalette</code> enum<br> <li> Group unified cross-platform themes with comment annotation<br> <li> Update <code>toCleverFerretTheme()</code> conversion function with mappings for all <br>new themes</ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/429/files#diff-5af67799ab3a175c1ea6ff9d70ec5c548ff3d5ec4168a74cd176a536dfcff15a">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CleverFerretTheme.kt</strong><dd><code>Map new themes to metallic effects and theme system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/CleverFerretTheme.kt

<ul><li>Add metallic effect mappings for six new theme palettes in <br><code>getMetallicEffectForTheme()</code><br> <li> Map new themes to their corresponding <code>CleverFerretTheme</code> values in <br>theme composition function<br> <li> Assign appropriate metallic gradients: Silver, Copper, Gold, and <br>Gunmetal</ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/429/files#diff-2819113b6c183a66adb880a7b383a2fbf7b020c12dda3f3115e2ff4a18d03b11">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ThemeMigration.kt</strong><dd><code>Add theme migration mappings for new palettes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ThemeMigration.kt

<ul><li>Add conversion mappings for six new themes in <code>toCleverFerretTheme()</code> <br>migration function<br> <li> Ensure proper theme migration from old <code>ThemePalette</code> to new <br><code>CleverFerretTheme</code> system</ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/429/files#diff-ce1730ffd36b344d98900640ee5b0f1a0920c78de0d9d10acd9b40b650c7f0a7">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ThemePreviewScreen.kt</strong><dd><code>Add theme descriptions for UI preview display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/ThemePreviewScreen.kt

<ul><li>Add user-friendly descriptions for six new theme palettes in <br><code>getThemeDescription()</code><br> <li> Provide descriptive labels highlighting color combinations and theme <br>characteristics</ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/429/files#diff-bbc078339ed9b49480ffc6df488ebf5fecf2b25ec9e77244ad34b89cb9d535f5">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UnifiedThemeSystem.kt</strong><dd><code>Fix theme conversion and remove fallback behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CleverFerret/src/main/java/com/universalmedialibrary/ui/theme/UnifiedThemeSystem.kt

<ul><li>Add bidirectional conversion mappings for six new themes in <br><code>toThemePalette()</code> function<br> <li> Remove fallback behavior that mapped new themes to <code>NAVY_GOLD</code> causing <br>persistence loss<br> <li> Enable proper round-trip conversion between <code>CleverFerretTheme</code> and <br><code>ThemePalette</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Kaleaon/CleverFerret/pull/429/files#diff-9e8d685a576498161afb1006eadf6b5e50c2865adceed06ac70afb19baec0285">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

