### PR TITLE
Align build tooling with current build entrypoint and remove stale minimal-swap logic

### DIFF
--- a/tooling/build-scripts/ai-auto-setup.sh
+++ b/tooling/build-scripts/ai-auto-setup.sh
@@ -366,7 +366,7 @@ make_scripts_executable() {
     
     # AI-FRIENDLY: List of scripts that need execute permissions
     local scripts=(
-        "build_enhanced_permanent.sh"
+        "tooling/build-scripts/build-cleverferret.sh"
         "tooling/build-scripts/setup-build-environment.sh"
         "tooling/build-scripts/ai-auto-setup.sh"
     )
@@ -439,7 +439,7 @@ main() {
         log_success "Ready to build enhanced CleverFerret APK!"
         echo
         echo "📋 Next Steps for AI:"
-        echo "1. Run: ./build_enhanced_permanent.sh"
+        echo "1. Run: ./tooling/build-scripts/build-cleverferret.sh"
         echo "2. Check: builds/ directory for APK"
         echo "3. Verify: APK installs on Android device"
         echo

--- a/tooling/build-scripts/build-cleverferret.sh
+++ b/tooling/build-scripts/build-cleverferret.sh
@@ -8,13 +8,6 @@ echo "============================================"
 export ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"
 export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/build-tools/33.0.2:$ANDROID_HOME/platform-tools:$PATH"
 
-# PERMANENT FIX: Use minimal dependencies for reliable build
-if [ -f "CleverFerret/build.gradle.kts.minimal" ]; then
-    echo "📦 Using minimal dependencies for reliable build..."
-    cp CleverFerret/build.gradle.kts CleverFerret/build.gradle.kts.full 2>/dev/null || true
-    cp CleverFerret/build.gradle.kts.minimal CleverFerret/build.gradle.kts
-fi
-
 # Clean build
 echo "🧹 Cleaning build environment..."
 ./gradlew clean --no-daemon
@@ -43,12 +36,6 @@ if [ -f "CleverFerret/build/outputs/apk/debug/CleverFerret-debug.apk" ]; then
 else
     echo "❌ APK build failed"
     exit 1
-fi
-
-# Restore full dependencies
-if [ -f "CleverFerret/build.gradle.kts.full" ]; then
-    echo "🔄 Restoring full dependencies..."
-    cp CleverFerret/build.gradle.kts.full CleverFerret/build.gradle.kts
 fi
 
 echo "🎉 Build completed successfully!"

--- a/tooling/build-scripts/setup-build-environment.sh
+++ b/tooling/build-scripts/setup-build-environment.sh
@@ -282,13 +282,6 @@ echo "============================================"
 export ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"
 export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/build-tools/33.0.2:$ANDROID_HOME/platform-tools:$PATH"
 
-# PERMANENT FIX: Use minimal dependencies for reliable build
-if [ -f "CleverFerret/build.gradle.kts.minimal" ]; then
-    echo "📦 Using minimal dependencies for reliable build..."
-    cp CleverFerret/build.gradle.kts CleverFerret/build.gradle.kts.full 2>/dev/null || true
-    cp CleverFerret/build.gradle.kts.minimal CleverFerret/build.gradle.kts
-fi
-
 # Clean build
 echo "🧹 Cleaning build environment..."
 ./gradlew clean --no-daemon
@@ -317,12 +310,6 @@ if [ -f "CleverFerret/build/outputs/apk/debug/CleverFerret-debug.apk" ]; then
 else
     echo "❌ APK build failed"
     exit 1
-fi
-
-# Restore full dependencies
-if [ -f "CleverFerret/build.gradle.kts.full" ]; then
-    echo "🔄 Restoring full dependencies..."
-    cp CleverFerret/build.gradle.kts.full CleverFerret/build.gradle.kts
 fi
 
 echo "🎉 Build completed successfully!"

--- a/tooling/build-scripts/test-build-system.sh
+++ b/tooling/build-scripts/test-build-system.sh
@@ -90,25 +90,13 @@ run_test "Build tools available" "[ -f '$ANDROID_HOME/build-tools/33.0.2/aapt2' 
 log_info "3. Testing project structure..."
 run_test "Main module exists" "[ -d 'CleverFerret' ]"
 run_test "Build gradle exists" "[ -f 'CleverFerret/build.gradle.kts' ]"
-run_test "Minimal gradle exists" "[ -f 'CleverFerret/build.gradle.kts.minimal' ]"
 run_test "Android manifest exists" "[ -f 'CleverFerret/src/main/AndroidManifest.xml' ]"
 
 # AI-FRIENDLY: Test 4 - Dependency Resolution (lightweight test)
 log_info "4. Testing dependency resolution..."
-# Use minimal dependencies for faster testing
-if [ -f "CleverFerret/build.gradle.kts.minimal" ]; then
-    log_info "Using minimal dependencies for testing..."
-    cp CleverFerret/build.gradle.kts CleverFerret/build.gradle.kts.backup 2>/dev/null || true
-    cp CleverFerret/build.gradle.kts.minimal CleverFerret/build.gradle.kts
-fi
 
 run_test "Dependency resolution" "timeout 120s ./gradlew --no-daemon dependencies | head -10"
 run_test "Build tasks available" "./gradlew --no-daemon tasks | grep -q 'assembleDebug'"
-
-# Restore original build file
-if [ -f "CleverFerret/build.gradle.kts.backup" ]; then
-    mv CleverFerret/build.gradle.kts.backup CleverFerret/build.gradle.kts
-fi
 
 # AI-FRIENDLY: Test 5 - Signing Test
 log_info "5. Testing APK signing capability..."
@@ -148,7 +136,7 @@ if [ $TESTS_FAILED -eq 0 ]; then
     echo "All build system components are functioning properly."
     echo
     echo "📋 Next steps for AI:"
-    echo "1. Run full build: ./build_enhanced_permanent.sh"
+    echo "1. Run full build: ./tooling/build-scripts/build-cleverferret.sh"
     echo "2. Expected build time: 5-15 minutes"
     echo "3. Look for APK in builds/ directory"
     echo "4. APK should be ~17MB and properly signed"

--- a/tooling/build-scripts/verify-setup.sh
+++ b/tooling/build-scripts/verify-setup.sh
@@ -104,8 +104,8 @@ run_test "gradle.properties has memory config" "grep -q \"Xmx6144m\" gradle.prop
 
 # AI-FRIENDLY: Test 6 - Build Scripts
 log_info "6. Checking build scripts..."
-run_test "Main build script exists" "[ -f \"build_enhanced_permanent.sh\" ]"
-run_test "Main build script executable" "[ -x \"build_enhanced_permanent.sh\" ]"
+run_test "Main build script exists" "[ -f \"tooling/build-scripts/build-cleverferret.sh\" ]"
+run_test "Main build script executable" "[ -x \"tooling/build-scripts/build-cleverferret.sh\" ]"
 run_test "Setup script exists" "[ -f \"tooling/build-scripts/setup-build-environment.sh\" ]"
 run_test "AI setup script exists" "[ -f \"tooling/build-scripts/ai-auto-setup.sh\" ]"
 
@@ -117,7 +117,6 @@ run_test "Debug keystore exists" "[ -f \"\$HOME/.android/debug.keystore\" ]"
 log_info "8. Checking project structure..."
 run_test "CleverFerret module exists" "[ -d \"CleverFerret\" ]"
 run_test "Main build.gradle.kts exists" "[ -f \"CleverFerret/build.gradle.kts\" ]"
-run_test "Minimal build.gradle.kts exists" "[ -f \"CleverFerret/build.gradle.kts.minimal\" ]"
 run_test "MainActivity.kt exists" "[ -f \"CleverFerret/src/main/java/com/universalmedialibrary/MainActivity.kt\" ]"
 
 # AI-FRIENDLY: Test 9 - System Resources  
@@ -156,7 +155,7 @@ if [ $TESTS_FAILED -eq 0 ]; then
     echo "Your CleverFerret build environment is properly configured."
     echo
     echo "📋 Next steps for AI:"
-    echo "1. Run: ./build_enhanced_permanent.sh"
+    echo "1. Run: ./tooling/build-scripts/build-cleverferret.sh"
     echo "2. Wait for build completion (5-15 minutes)"
     echo "3. Check builds/ directory for APK file"
     echo "4. Install APK on Android device for testing"


### PR DESCRIPTION
### Motivation
- The repository referenced a removed/incorrect entrypoint (`build_enhanced_permanent.sh`) and optional minimal `build.gradle.kts.minimal` swap logic, causing verification, guidance, and wrapper scripts to point to files that no longer reflect the repo.
- Update scripts and messages so AI-facing guidance and automated checks reference the real build entrypoint and present accurate next steps.

### Description
- Replaced verification checks and user-facing "Run:" hints that referenced `./build_enhanced_permanent.sh` with the actual entrypoint `./tooling/build-scripts/build-cleverferret.sh` in `tooling/build-scripts/verify-setup.sh`, `tooling/build-scripts/ai-auto-setup.sh`, and `tooling/build-scripts/test-build-system.sh`.
- Removed project checks and temporary-swap logic for `CleverFerret/build.gradle.kts.minimal` from `tooling/build-scripts/test-build-system.sh`, `tooling/build-scripts/build-cleverferret.sh`, and the generated wrapper in `tooling/build-scripts/setup-build-environment.sh` so builds use the real checked-in Gradle configuration.
- Updated the list of scripts made executable by the AI setup to include `tooling/build-scripts/build-cleverferret.sh` instead of the stale filename in `tooling/build-scripts/ai-auto-setup.sh`.
- Cleaned up log messages and next-step instructions so all logs, help text, and wrapper templates reflect the actual scripts and files present in the repo.

### Testing
- Ran a shell-syntax check with `bash -n` across the modified scripts: `bash -n tooling/build-scripts/verify-setup.sh tooling/build-scripts/ai-auto-setup.sh tooling/build-scripts/test-build-system.sh tooling/build-scripts/build-cleverferret.sh tooling/build-scripts/setup-build-environment.sh`, and it exited successfully.
- Searched for stale references using ripgrep with `rg -n "build_enhanced_permanent|build.gradle.kts.minimal|minimal dependencies|build.gradle.kts.full" tooling/build-scripts` and confirmed no remaining matches.
- Changes were committed and a PR message was prepared reflecting the updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e262f62a7c83238c0cf2203a2fef05)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR cleans up build tooling by replacing references to a stale build entrypoint (`build_enhanced_permanent.sh`) with the actual script (`tooling/build-scripts/build-cleverferret.sh`) across verification, testing, and setup scripts. It also removes obsolete logic that temporarily swapped `build.gradle.kts.minimal` files during builds, ensuring all scripts now reference the real checked-in Gradle configuration. The changes update executable permissions lists, user-facing instructions, and test assertions to reflect the current repository structure.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tooling/build-scripts/verify-setup.sh` |
| 2 | `tooling/build-scripts/test-build-system.sh` |
| 3 | `tooling/build-scripts/ai-auto-setup.sh` |
| 4 | `tooling/build-scripts/build-cleverferret.sh` |
| 5 | `tooling/build-scripts/setup-build-environment.sh` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->