### PR TITLE
Unify Android SDK resolution across build scripts

### DIFF
--- a/tooling/build-scripts/ai-auto-setup.sh
+++ b/tooling/build-scripts/ai-auto-setup.sh
@@ -50,10 +50,47 @@ log_error() {
 
 # AI-FRIENDLY: Configuration constants that AI can easily understand
 readonly REQUIRED_JAVA_VERSION="17"
-readonly ANDROID_SDK_PATH="/opt/android-sdk"
 readonly BUILD_TOOLS_VERSION="33.0.2"
 readonly ANDROID_COMPILE_SDK="34"
 readonly PROJECT_ROOT="$(pwd)"
+
+resolve_os_default_sdk() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "$HOME/Library/Android/sdk"
+    elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+        echo "${LOCALAPPDATA:-$HOME/AppData/Local}/Android/Sdk"
+    else
+        echo "$HOME/Android/Sdk"
+    fi
+}
+
+resolve_android_sdk_root() {
+    local os_default
+    os_default="$(resolve_os_default_sdk)"
+
+    if [ -n "$ANDROID_HOME" ]; then
+        echo "$ANDROID_HOME"
+    elif [ -n "$ANDROID_SDK_ROOT" ]; then
+        echo "$ANDROID_SDK_ROOT"
+    elif [ -d "$PROJECT_ROOT/android-sdk" ]; then
+        echo "$PROJECT_ROOT/android-sdk"
+    else
+        echo "$os_default"
+    fi
+}
+
+select_build_tools_version() {
+    local sdk_root="$1"
+    local selected_version=""
+
+    if [ -d "$sdk_root/build-tools/$BUILD_TOOLS_VERSION" ]; then
+        selected_version="$BUILD_TOOLS_VERSION"
+    elif [ -d "$sdk_root/build-tools" ]; then
+        selected_version="$(ls -1 "$sdk_root/build-tools" 2>/dev/null | sort -V | tail -n1)"
+    fi
+
+    echo "${selected_version:-$BUILD_TOOLS_VERSION}"
+}
 
 # AI-FRIENDLY: Platform detection with clear logic
 detect_platform() {
@@ -123,18 +160,17 @@ install_java() {
 
 # AI-FRIENDLY: Android SDK installation with step-by-step logging
 install_android_sdk() {
-    log_info "Setting up Android SDK at $ANDROID_SDK_PATH..."
+    log_info "Setting up Android SDK at $RESOLVED_ANDROID_SDK_ROOT..."
     
     # AI-FRIENDLY: Check if SDK already exists
-    if [ -d "$ANDROID_SDK_PATH" ] && [ -f "$ANDROID_SDK_PATH/cmdline-tools/latest/bin/sdkmanager" ]; then
+    if [ -d "$RESOLVED_ANDROID_SDK_ROOT" ] && [ -f "$RESOLVED_ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" ]; then
         log_success "Android SDK already installed"
     else
         log_info "Creating Android SDK directory..."
-        sudo mkdir -p "$ANDROID_SDK_PATH"
-        sudo chown -R $(whoami):$(whoami) "$ANDROID_SDK_PATH"
+        mkdir -p "$RESOLVED_ANDROID_SDK_ROOT"
         
         log_info "Downloading Android Command Line Tools..."
-        cd "$ANDROID_SDK_PATH"
+        cd "$RESOLVED_ANDROID_SDK_ROOT"
         
         # AI-FRIENDLY: Platform-specific download URLs
         case $PLATFORM in
@@ -173,9 +209,10 @@ install_android_sdk() {
     
     # AI-FRIENDLY: Set environment variables with clear logging
     log_info "Configuring environment variables..."
-    export ANDROID_HOME="$ANDROID_SDK_PATH"
-    export ANDROID_SDK_ROOT="$ANDROID_SDK_PATH"
-    export PATH="$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION:$ANDROID_HOME/platform-tools"
+    export ANDROID_HOME="$RESOLVED_ANDROID_SDK_ROOT"
+    export ANDROID_SDK_ROOT="$RESOLVED_ANDROID_SDK_ROOT"
+    SELECTED_BUILD_TOOLS_VERSION="$(select_build_tools_version "$ANDROID_HOME")"
+    export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$SELECTED_BUILD_TOOLS_VERSION:$PATH"
     
     # AI-FRIENDLY: Install required SDK components with progress logging
     log_info "Installing Android SDK components..."
@@ -203,7 +240,8 @@ install_android_sdk() {
     
     # AI-FRIENDLY: Ensure AAPT2 is executable (critical for builds)
     log_info "Making build tools executable..."
-    chmod +x "$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION"/* 2>/dev/null || true
+    SELECTED_BUILD_TOOLS_VERSION="$(select_build_tools_version "$ANDROID_HOME")"
+    chmod +x "$ANDROID_HOME/build-tools/$SELECTED_BUILD_TOOLS_VERSION"/* 2>/dev/null || true
     
     log_success "Android SDK setup completed"
 }
@@ -390,10 +428,10 @@ create_environment_file() {
 # CleverFerret Environment Setup
 # Source this file to set up environment variables
 
-export ANDROID_HOME="$ANDROID_SDK_PATH"
-export ANDROID_SDK_ROOT="$ANDROID_SDK_PATH"
+export ANDROID_HOME="$RESOLVED_ANDROID_SDK_ROOT"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
 export JAVA_HOME=\${JAVA_HOME:-\$(readlink -f /usr/bin/java | sed "s:bin/java::")}
-export PATH="\$PATH:\$ANDROID_HOME/cmdline-tools/latest/bin:\$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION:\$ANDROID_HOME/platform-tools"
+export PATH="\$ANDROID_HOME/cmdline-tools/latest/bin:\$ANDROID_HOME/platform-tools:\$ANDROID_HOME/build-tools/$SELECTED_BUILD_TOOLS_VERSION:\$PATH"
 
 echo "✅ CleverFerret environment variables set"
 echo "ANDROID_HOME: \$ANDROID_HOME"
@@ -419,6 +457,9 @@ main() {
     
     # AI-FRIENDLY: Execute setup steps with error handling
     detect_platform
+    RESOLVED_ANDROID_SDK_ROOT="$(resolve_android_sdk_root)"
+    SELECTED_BUILD_TOOLS_VERSION="$BUILD_TOOLS_VERSION"
+    log_info "Resolved Android SDK path: $RESOLVED_ANDROID_SDK_ROOT"
     install_java
     install_android_sdk
     create_build_configuration
@@ -432,8 +473,8 @@ main() {
         echo "🎉 CleverFerret Setup Completed Successfully!"
         echo "============================================"
         log_success "Java 17: Available"
-        log_success "Android SDK: Installed at $ANDROID_SDK_PATH"
-        log_success "Build Tools: $BUILD_TOOLS_VERSION (Compatible)"
+        log_success "Android SDK: Installed at $RESOLVED_ANDROID_SDK_ROOT"
+        log_success "Build Tools: $SELECTED_BUILD_TOOLS_VERSION"
         log_success "Environment: Configured"
         log_success "Scripts: Executable"
         log_success "Ready to build enhanced CleverFerret APK!"
@@ -455,8 +496,9 @@ main() {
         echo "🔧 Troubleshooting:"
         echo "1. Ensure internet connection is available"
         echo "2. Check available disk space (need ~2GB)"
-        echo "3. Verify system permissions"
-        echo "4. Retry with: ./tooling/build-scripts/ai-auto-setup.sh"
+        echo "3. Verify SDK path: $RESOLVED_ANDROID_SDK_ROOT"
+        echo "4. Verify system permissions"
+        echo "5. Retry with: ./tooling/build-scripts/ai-auto-setup.sh"
         echo
         echo "❌ Setup failed"
         exit 1

--- a/tooling/build-scripts/build-cleverferret.sh
+++ b/tooling/build-scripts/build-cleverferret.sh
@@ -4,9 +4,59 @@ set -e
 echo "🔨 Building CleverFerret with Permanent Fixes"
 echo "============================================"
 
+resolve_repo_root() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cd "$script_dir/../.." && pwd
+}
+
+resolve_os_default_sdk() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "$HOME/Library/Android/sdk"
+    elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+        echo "${LOCALAPPDATA:-$HOME/AppData/Local}/Android/Sdk"
+    else
+        echo "$HOME/Android/Sdk"
+    fi
+}
+
+resolve_android_sdk_root() {
+    local repo_root os_default
+    repo_root="$(resolve_repo_root)"
+    os_default="$(resolve_os_default_sdk)"
+
+    if [ -n "$ANDROID_HOME" ]; then
+        echo "$ANDROID_HOME"
+    elif [ -n "$ANDROID_SDK_ROOT" ]; then
+        echo "$ANDROID_SDK_ROOT"
+    elif [ -d "$repo_root/android-sdk" ]; then
+        echo "$repo_root/android-sdk"
+    else
+        echo "$os_default"
+    fi
+}
+
+select_build_tools_version() {
+    local sdk_root="$1"
+    local preferred_version="33.0.2"
+    local selected_version=""
+
+    if [ -d "$sdk_root/build-tools/$preferred_version" ]; then
+        selected_version="$preferred_version"
+    elif [ -d "$sdk_root/build-tools" ]; then
+        selected_version="$(ls -1 "$sdk_root/build-tools" 2>/dev/null | sort -V | tail -n1)"
+    fi
+
+    echo "${selected_version:-$preferred_version}"
+}
+
 # Set environment
-export ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"
-export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/build-tools/33.0.2:$ANDROID_HOME/platform-tools:$PATH"
+export ANDROID_HOME="$(resolve_android_sdk_root)"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+BUILD_TOOLS_VERSION="$(select_build_tools_version "$ANDROID_HOME")"
+export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION:$PATH"
+echo "📍 Resolved Android SDK: $ANDROID_HOME"
+echo "🧰 Using build-tools: $BUILD_TOOLS_VERSION"
 
 # PERMANENT FIX: Use minimal dependencies for reliable build
 if [ -f "CleverFerret/build.gradle.kts.minimal" ]; then
@@ -33,7 +83,7 @@ if [ -f "CleverFerret/build/outputs/apk/debug/CleverFerret-debug.apk" ]; then
     mkdir -p builds
     cp "$APK_PATH" "$SIGNED_APK"
     
-    "$ANDROID_HOME/build-tools/33.0.2/apksigner" sign \
+    "$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/apksigner" sign \
         --ks "$HOME/.android/debug.keystore" --ks-pass pass:android --key-pass pass:android \
         "$SIGNED_APK"
     

--- a/tooling/build-scripts/enhanced-sdk-installer.sh
+++ b/tooling/build-scripts/enhanced-sdk-installer.sh
@@ -7,7 +7,6 @@
 set -e  # Exit on any error
 
 # Configuration
-ANDROID_SDK_ROOT="${ANDROID_HOME:-/opt/android-sdk}"
 REQUIRED_BUILD_TOOLS="34.0.0"
 REQUIRED_PLATFORMS="android-34"
 REQUIRED_CMAKE="3.22.1"
@@ -24,6 +23,48 @@ log_info() { echo -e "${BLUE}ℹ️  $1${NC}"; }
 log_success() { echo -e "${GREEN}✅ $1${NC}"; }
 log_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
 log_error() { echo -e "${RED}❌ $1${NC}"; }
+
+resolve_repo_root() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cd "$script_dir/../.." && pwd
+}
+
+resolve_os_default_sdk() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "$HOME/Library/Android/sdk"
+    elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+        echo "${LOCALAPPDATA:-$HOME/AppData/Local}/Android/Sdk"
+    else
+        echo "$HOME/Android/Sdk"
+    fi
+}
+
+resolve_android_sdk_root() {
+    local repo_root os_default
+    repo_root="$(resolve_repo_root)"
+    os_default="$(resolve_os_default_sdk)"
+
+    if [ -n "$ANDROID_HOME" ]; then
+        echo "$ANDROID_HOME"
+    elif [ -n "$ANDROID_SDK_ROOT" ]; then
+        echo "$ANDROID_SDK_ROOT"
+    elif [ -d "$repo_root/android-sdk" ]; then
+        echo "$repo_root/android-sdk"
+    else
+        echo "$os_default"
+    fi
+}
+
+select_build_tools_version() {
+    if [ -d "$ANDROID_SDK_ROOT/build-tools/$REQUIRED_BUILD_TOOLS" ]; then
+        SELECTED_BUILD_TOOLS="$REQUIRED_BUILD_TOOLS"
+    elif [ -d "$ANDROID_SDK_ROOT/build-tools" ]; then
+        SELECTED_BUILD_TOOLS="$(ls -1 "$ANDROID_SDK_ROOT/build-tools" 2>/dev/null | sort -V | tail -n1)"
+    fi
+
+    SELECTED_BUILD_TOOLS="${SELECTED_BUILD_TOOLS:-$REQUIRED_BUILD_TOOLS}"
+}
 
 # Platform detection
 detect_platform() {
@@ -199,17 +240,18 @@ verify_installation() {
 # Set up environment variables
 setup_environment() {
     log_info "Setting up environment variables..."
+    select_build_tools_version
     
     export ANDROID_HOME="$ANDROID_SDK_ROOT"
     export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
-    export PATH="$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$PATH"
+    export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools:$ANDROID_SDK_ROOT/build-tools/$SELECTED_BUILD_TOOLS:$PATH"
     
     # Create environment file for future use
     cat > /tmp/android_env.sh << EOF
 # Android SDK Environment Variables
 export ANDROID_HOME="$ANDROID_SDK_ROOT"
 export ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT"
-export PATH="\$ANDROID_SDK_ROOT/platform-tools:\$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:\$PATH"
+export PATH="\$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:\$ANDROID_SDK_ROOT/platform-tools:\$ANDROID_SDK_ROOT/build-tools/$SELECTED_BUILD_TOOLS:\$PATH"
 EOF
     
     log_info "Environment variables set. Source /tmp/android_env.sh in your shell profile."
@@ -218,6 +260,8 @@ EOF
 
 # Main installation function
 main() {
+    ANDROID_SDK_ROOT="$(resolve_android_sdk_root)"
+
     log_info "🚀 Starting CleverFerret Enhanced SDK Installation"
     log_info "Platform: $(detect_platform)"
     log_info "SDK Root: $ANDROID_SDK_ROOT"

--- a/tooling/build-scripts/setup-build-environment.sh
+++ b/tooling/build-scripts/setup-build-environment.sh
@@ -12,23 +12,6 @@ echo "=============================================================="
 export BUILD_TOOLS_VERSION="33.0.2"
 export COMPILE_SDK_VERSION="34"
 
-# Auto-detect Android SDK location
-# Priority: 1) Pre-set ANDROID_HOME, 2) Workspace/container, 3) Standard Android Studio
-if [ -z "$ANDROID_HOME" ]; then
-    if [ -d "/workspace/android-sdk" ]; then
-        # Workspace/container environment
-        export ANDROID_HOME="/workspace/android-sdk"
-    elif [ -d "$HOME/Android/Sdk" ]; then
-        # Standard Android Studio location
-        export ANDROID_HOME="$HOME/Android/Sdk"
-    else
-        # Fallback to default path to let the build system provide a clear error
-        export ANDROID_HOME="$HOME/Android/Sdk"
-    fi
-fi
-
-export ANDROID_SDK_ROOT="$ANDROID_HOME"
-
 export JAVA_VERSION="17"
 
 # Colors for output
@@ -52,6 +35,52 @@ log_warning() {
 
 log_error() {
     echo -e "${RED}❌ $1${NC}"
+}
+
+resolve_repo_root() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cd "$script_dir/../.." && pwd
+}
+
+resolve_os_default_sdk() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "$HOME/Library/Android/sdk"
+    elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+        echo "${LOCALAPPDATA:-$HOME/AppData/Local}/Android/Sdk"
+    else
+        echo "$HOME/Android/Sdk"
+    fi
+}
+
+resolve_android_sdk_root() {
+    local repo_root os_default
+    repo_root="$(resolve_repo_root)"
+    os_default="$(resolve_os_default_sdk)"
+
+    if [ -n "$ANDROID_HOME" ]; then
+        echo "$ANDROID_HOME"
+    elif [ -n "$ANDROID_SDK_ROOT" ]; then
+        echo "$ANDROID_SDK_ROOT"
+    elif [ -d "$repo_root/android-sdk" ]; then
+        echo "$repo_root/android-sdk"
+    else
+        echo "$os_default"
+    fi
+}
+
+select_build_tools_version() {
+    local sdk_root="$1"
+    local preferred_version="$BUILD_TOOLS_VERSION"
+    local selected_version=""
+
+    if [ -d "$sdk_root/build-tools/$preferred_version" ]; then
+        selected_version="$preferred_version"
+    elif [ -d "$sdk_root/build-tools" ]; then
+        selected_version="$(ls -1 "$sdk_root/build-tools" 2>/dev/null | sort -V | tail -n1)"
+    fi
+
+    echo "${selected_version:-$preferred_version}"
 }
 
 # Detect operating system
@@ -141,7 +170,8 @@ install_android_sdk() {
     fi
     
     # Set up PATH
-    export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$PATH"
+    SELECTED_BUILD_TOOLS_VERSION="$(select_build_tools_version "$ANDROID_HOME")"
+    export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$SELECTED_BUILD_TOOLS_VERSION:$PATH"
     
     # PERMANENT FIX: Install specific compatible versions
     log_info "Installing Android SDK components with permanent fixes..."
@@ -279,8 +309,58 @@ echo "🔨 Building CleverFerret with Permanent Fixes"
 echo "============================================"
 
 # Set environment
-export ANDROID_HOME="${ANDROID_HOME:-$HOME/Android/Sdk}"
-export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/build-tools/33.0.2:$ANDROID_HOME/platform-tools:$PATH"
+resolve_repo_root() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cd "$script_dir/../.." && pwd
+}
+
+resolve_os_default_sdk() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "$HOME/Library/Android/sdk"
+    elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+        echo "${LOCALAPPDATA:-$HOME/AppData/Local}/Android/Sdk"
+    else
+        echo "$HOME/Android/Sdk"
+    fi
+}
+
+resolve_android_sdk_root() {
+    local repo_root os_default
+    repo_root="$(resolve_repo_root)"
+    os_default="$(resolve_os_default_sdk)"
+
+    if [ -n "$ANDROID_HOME" ]; then
+        echo "$ANDROID_HOME"
+    elif [ -n "$ANDROID_SDK_ROOT" ]; then
+        echo "$ANDROID_SDK_ROOT"
+    elif [ -d "$repo_root/android-sdk" ]; then
+        echo "$repo_root/android-sdk"
+    else
+        echo "$os_default"
+    fi
+}
+
+select_build_tools_version() {
+    local sdk_root="$1"
+    local preferred_version="33.0.2"
+    local selected_version=""
+
+    if [ -d "$sdk_root/build-tools/$preferred_version" ]; then
+        selected_version="$preferred_version"
+    elif [ -d "$sdk_root/build-tools" ]; then
+        selected_version="$(ls -1 "$sdk_root/build-tools" 2>/dev/null | sort -V | tail -n1)"
+    fi
+
+    echo "${selected_version:-$preferred_version}"
+}
+
+export ANDROID_HOME="$(resolve_android_sdk_root)"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+BUILD_TOOLS_VERSION="$(select_build_tools_version "$ANDROID_HOME")"
+export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION:$PATH"
+echo "📍 Resolved Android SDK: $ANDROID_HOME"
+echo "🧰 Using build-tools: $BUILD_TOOLS_VERSION"
 
 # PERMANENT FIX: Use minimal dependencies for reliable build
 if [ -f "CleverFerret/build.gradle.kts.minimal" ]; then
@@ -307,7 +387,7 @@ if [ -f "CleverFerret/build/outputs/apk/debug/CleverFerret-debug.apk" ]; then
     mkdir -p builds
     cp "$APK_PATH" "$SIGNED_APK"
     
-    "$ANDROID_HOME/build-tools/33.0.2/apksigner" sign \
+    "$ANDROID_HOME/build-tools/$BUILD_TOOLS_VERSION/apksigner" sign \
         --ks "$HOME/.android/debug.keystore" --ks-pass pass:android --key-pass pass:android \
         "$SIGNED_APK"
     
@@ -336,6 +416,10 @@ EOF
 main() {
     echo
     log_info "Starting CleverFerret build environment setup..."
+    export ANDROID_HOME="$(resolve_android_sdk_root)"
+    export ANDROID_SDK_ROOT="$ANDROID_HOME"
+    export SELECTED_BUILD_TOOLS_VERSION="$BUILD_TOOLS_VERSION"
+    log_info "Resolved Android SDK path: $ANDROID_HOME"
     echo
     
     detect_os

--- a/tooling/build-scripts/verify-setup.sh
+++ b/tooling/build-scripts/verify-setup.sh
@@ -46,6 +46,52 @@ log_error() {
 TESTS_PASSED=0
 TESTS_FAILED=0
 
+resolve_repo_root() {
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cd "$script_dir/../.." && pwd
+}
+
+resolve_os_default_sdk() {
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        echo "$HOME/Library/Android/sdk"
+    elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+        echo "${LOCALAPPDATA:-$HOME/AppData/Local}/Android/Sdk"
+    else
+        echo "$HOME/Android/Sdk"
+    fi
+}
+
+resolve_android_sdk_root() {
+    local repo_root os_default
+    repo_root="$(resolve_repo_root)"
+    os_default="$(resolve_os_default_sdk)"
+
+    if [ -n "$ANDROID_HOME" ]; then
+        echo "$ANDROID_HOME"
+    elif [ -n "$ANDROID_SDK_ROOT" ]; then
+        echo "$ANDROID_SDK_ROOT"
+    elif [ -d "$repo_root/android-sdk" ]; then
+        echo "$repo_root/android-sdk"
+    else
+        echo "$os_default"
+    fi
+}
+
+select_build_tools_version() {
+    local sdk_root="$1"
+    local preferred_version="33.0.2"
+    local selected_version=""
+
+    if [ -d "$sdk_root/build-tools/$preferred_version" ]; then
+        selected_version="$preferred_version"
+    elif [ -d "$sdk_root/build-tools" ]; then
+        selected_version="$(ls -1 "$sdk_root/build-tools" 2>/dev/null | sort -V | tail -n1)"
+    fi
+
+    echo "${selected_version:-$preferred_version}"
+}
+
 # AI-FRIENDLY: Test execution function
 run_test() {
     local test_name="$1"
@@ -73,6 +119,15 @@ echo "🔍 CleverFerret Build Environment Verification"
 echo "=============================================="
 echo
 
+RESOLVED_ANDROID_SDK_ROOT="$(resolve_android_sdk_root)"
+RESOLVED_BUILD_TOOLS_VERSION="$(select_build_tools_version "$RESOLVED_ANDROID_SDK_ROOT")"
+export ANDROID_HOME="$RESOLVED_ANDROID_SDK_ROOT"
+export ANDROID_SDK_ROOT="$RESOLVED_ANDROID_SDK_ROOT"
+export PATH="$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools/$RESOLVED_BUILD_TOOLS_VERSION:$PATH"
+
+log_info "Resolved Android SDK root: $RESOLVED_ANDROID_SDK_ROOT"
+log_info "Resolved build-tools version: $RESOLVED_BUILD_TOOLS_VERSION"
+
 # AI-FRIENDLY: Test 1 - Java Installation
 log_info "1. Checking Java installation..."
 run_test "Java 17 installed" "java -version 2>&1 | grep -q '17'"
@@ -81,19 +136,19 @@ run_test "Java executable available" "command -v java"
 # AI-FRIENDLY: Test 2 - Android SDK
 log_info "2. Checking Android SDK..."
 run_test "ANDROID_HOME set" "[ -n \"\$ANDROID_HOME\" ]"
-run_test "Android SDK directory exists" "[ -d \"/opt/android-sdk\" ]"
-run_test "Command line tools available" "[ -f \"/opt/android-sdk/cmdline-tools/latest/bin/sdkmanager\" ]"
+run_test "Android SDK directory exists" "[ -d \"$RESOLVED_ANDROID_SDK_ROOT\" ]"
+run_test "Command line tools available" "[ -f \"$RESOLVED_ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager\" ]"
 
 # AI-FRIENDLY: Test 3 - Build Tools  
 log_info "3. Checking build tools..."
-run_test "Build tools 33.0.2 installed" "[ -d \"/opt/android-sdk/build-tools/33.0.2\" ]"
-run_test "AAPT2 executable" "[ -x \"/opt/android-sdk/build-tools/33.0.2/aapt2\" ]"
-run_test "AAPT2 working" "/opt/android-sdk/build-tools/33.0.2/aapt2 version"
+run_test "Build tools $RESOLVED_BUILD_TOOLS_VERSION installed" "[ -d \"$RESOLVED_ANDROID_SDK_ROOT/build-tools/$RESOLVED_BUILD_TOOLS_VERSION\" ]"
+run_test "AAPT2 executable" "[ -x \"$RESOLVED_ANDROID_SDK_ROOT/build-tools/$RESOLVED_BUILD_TOOLS_VERSION/aapt2\" ]"
+run_test "AAPT2 working" "\"$RESOLVED_ANDROID_SDK_ROOT/build-tools/$RESOLVED_BUILD_TOOLS_VERSION/aapt2\" version"
 
 # AI-FRIENDLY: Test 4 - Platform Tools
 log_info "4. Checking platform tools..."
-run_test "Platform 34 installed" "[ -d \"/opt/android-sdk/platforms/android-34\" ]"
-run_test "Platform tools available" "[ -d \"/opt/android-sdk/platform-tools\" ]"
+run_test "Platform 34 installed" "[ -d \"$RESOLVED_ANDROID_SDK_ROOT/platforms/android-34\" ]"
+run_test "Platform tools available" "[ -d \"$RESOLVED_ANDROID_SDK_ROOT/platform-tools\" ]"
 
 # AI-FRIENDLY: Test 5 - Configuration Files
 log_info "5. Checking configuration files..."
@@ -139,7 +194,7 @@ run_test "Disk space available" "df . | awk 'NR==2 {exit (\$4<2000000) ? 1 : 0}'
 # AI-FRIENDLY: Test 10 - Environment Variables
 log_info "10. Checking environment variables..."
 run_test "ANDROID_HOME in PATH" "echo \$PATH | grep -q \$ANDROID_HOME"
-run_test "Build tools in PATH" "echo \$PATH | grep -q \"build-tools/33.0.2\""
+run_test "Build tools in PATH" "echo \$PATH | grep -q \"build-tools/$RESOLVED_BUILD_TOOLS_VERSION\""
 
 echo
 echo "📊 VERIFICATION SUMMARY"
@@ -173,8 +228,8 @@ else
     echo "📋 Recommended fixes for AI:"
     echo "1. Re-run setup: ./tooling/build-scripts/ai-auto-setup.sh"
     echo "2. Check error messages above for specific issues"
-    echo "3. Ensure internet connection and sufficient disk space"
-    echo "4. Verify system permissions"
+    echo "3. Confirm SDK path is valid: $RESOLVED_ANDROID_SDK_ROOT"
+    echo "4. Ensure internet connection, sufficient disk space, and permissions"
     echo
     echo "❌ Verification failed"
     exit 1


### PR DESCRIPTION
### Motivation
- Ensure all build/setup scripts discover the Android SDK consistently using the order: `ANDROID_HOME` -> `ANDROID_SDK_ROOT` -> repo-local `android-sdk` -> OS default. 
- Remove brittle hardcoded SDK paths and surface the resolved SDK path in diagnostics to make troubleshooting deterministic.

### Description
- Added SDK resolver helpers (`resolve_repo_root`, `resolve_os_default_sdk`, `resolve_android_sdk_root`) and a build-tools selector (`select_build_tools_version`) and applied them to `ai-auto-setup.sh`, `setup-build-environment.sh`, `verify-setup.sh`, `enhanced-sdk-installer.sh`, and `build-cleverferret.sh`.
- Replaced hardcoded `/opt/android-sdk/...` checks in `verify-setup.sh` with checks against the resolved SDK root and resolved build-tools version, and export `ANDROID_HOME`/`ANDROID_SDK_ROOT` and `PATH` from resolved values before validation.
- Standardized `PATH` and environment exports to consistently include `cmdline-tools/latest/bin`, `platform-tools`, and a selected `build-tools/<version>` folder, and updated signing and env-file outputs to use the selected build-tools variable.
- Improved user/troubleshooting messages to print the resolved SDK root and selected build-tools version explicitly.

### Testing
- Ran syntax validation: `bash -n tooling/build-scripts/ai-auto-setup.sh tooling/build-scripts/setup-build-environment.sh tooling/build-scripts/verify-setup.sh tooling/build-scripts/enhanced-sdk-installer.sh tooling/build-scripts/build-cleverferret.sh` which completed successfully.
- Verified repository state with `git status` and committed the changes; commit created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e262f8a7708323a351fb1345d57081)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR standardizes Android SDK resolution logic across all build scripts by introducing shared helper functions (`resolve_android_sdk_root`, `resolve_os_default_sdk`, `select_build_tools_version`) that discover the SDK location in a consistent order: `ANDROID_HOME` environment variable, `ANDROID_SDK_ROOT` environment variable, repo-local `android-sdk` directory, or OS-specific default path. The changes remove hardcoded SDK paths like `/opt/android-sdk`, dynamically select the best available build-tools version, standardize `PATH` construction to include `cmdline-tools/latest/bin`, `platform-tools`, and selected build-tools directory, and improve diagnostic messaging by explicitly reporting the resolved SDK path and build-tools version to aid troubleshooting.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `tooling/build-scripts/verify-setup.sh` |
| 2 | `tooling/build-scripts/ai-auto-setup.sh` |
| 3 | `tooling/build-scripts/setup-build-environment.sh` |
| 4 | `tooling/build-scripts/enhanced-sdk-installer.sh` |
| 5 | `tooling/build-scripts/build-cleverferret.sh` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->