### PR TITLE
Harden free media UI null handling and structured crash logging

### DIFF
--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/FreeMediaScreen.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/FreeMediaScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
@@ -193,7 +193,10 @@ private fun MediaList(
         contentPadding = PaddingValues(bottom = 32.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        items(items, key = { it.id }) { item ->
+        itemsIndexed(
+            items = items,
+            key = { index, item -> freeMediaItemKey(item = item, index = index) }
+        ) { _, item ->
             MediaCard(
                 item = item,
                 onDownload = onDownload,
@@ -210,6 +213,8 @@ private fun MediaCard(
     onDownload: (FreeMediaDownloadOption) -> Unit,
     onOpenLink: (String) -> Unit
 ) {
+    val uiModel = item.toUiModel()
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -218,7 +223,7 @@ private fun MediaCard(
             horizontalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             AsyncImage(
-                model = item.thumbnailUrl,
+                model = uiModel.thumbnailUrl,
                 contentDescription = "${item.title} thumbnail",
                 modifier = Modifier
                     .size(width = 120.dp, height = 90.dp)
@@ -246,13 +251,16 @@ private fun MediaCard(
                     style = MaterialTheme.typography.labelSmall,
                     color = MaterialTheme.colorScheme.primary
                 )
-                item.year?.let {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
+                Text(
+                    text = uiModel.yearLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text = uiModel.durationLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
 
@@ -305,6 +313,46 @@ private fun MediaCard(
                 }
             }
         }
+    }
+}
+
+internal fun freeMediaItemKey(item: FreeMediaItem, index: Int): String {
+    val normalizedId = item.id.trim()
+    if (normalizedId.isNotEmpty()) {
+        return "${item.type.name}:$normalizedId"
+    }
+
+    val fallbackTitle = item.title.ifBlank { "untitled" }
+    val fallbackYear = item.year?.takeIf { it.isNotBlank() } ?: "unknown-year"
+    return "${item.type.name}:$fallbackTitle:$fallbackYear:$index"
+}
+
+internal data class FreeMediaItemUiModel(
+    val thumbnailUrl: String?,
+    val yearLabel: String,
+    val durationLabel: String
+)
+
+internal fun FreeMediaItem.toUiModel(): FreeMediaItemUiModel {
+    return FreeMediaItemUiModel(
+        thumbnailUrl = thumbnailUrl?.takeIf { it.isNotBlank() },
+        yearLabel = year?.takeIf { it.isNotBlank() } ?: "Year unknown",
+        durationLabel = runtimeSeconds
+            ?.takeIf { it > 0 }
+            ?.let(::formatRuntimeLabel)
+            ?: "Duration unknown"
+    )
+}
+
+private fun formatRuntimeLabel(seconds: Long): String {
+    val totalMinutes = seconds / 60
+    val hours = totalMinutes / 60
+    val minutes = totalMinutes % 60
+
+    return when {
+        hours > 0 -> "Duration: ${hours}h ${minutes}m"
+        totalMinutes > 0 -> "Duration: ${totalMinutes}m"
+        else -> "Duration: <1m"
     }
 }
 

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/FreeMediaViewModel.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/FreeMediaViewModel.kt
@@ -2,6 +2,7 @@ package com.universalmedialibrary.ui.media
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.universalmedialibrary.core.logging.AppLogger
 import com.universalmedialibrary.services.media.free.FreeMediaItem
 import com.universalmedialibrary.services.media.free.FreeMediaService
 import com.universalmedialibrary.services.media.free.FreeMediaType
@@ -84,6 +85,15 @@ class FreeMediaViewModel @Inject constructor(
                 // Job was cancelled (e.g., by user switching tabs), don't update state
                 throw e
             } catch (e: Exception) {
+                AppLogger.error(
+                    tag = "FreeMediaViewModel",
+                    message = "Failed to load free media catalog",
+                    throwable = e,
+                    context = mapOf(
+                        "activeType" to currentType.name,
+                        "query" to currentQuery.ifBlank { "<blank>" }
+                    )
+                )
                 _uiState.value = _uiState.value.copy(
                     isLoading = false,
                     error = e.message ?: "Failed to load media items"

--- a/CleverFerret/src/test/java/com/universalmedialibrary/ui/media/FreeMediaScreenModelTest.kt
+++ b/CleverFerret/src/test/java/com/universalmedialibrary/ui/media/FreeMediaScreenModelTest.kt
@@ -1,0 +1,48 @@
+package com.universalmedialibrary.ui.media
+
+import com.universalmedialibrary.services.media.free.FreeMediaItem
+import com.universalmedialibrary.services.media.free.FreeMediaSource
+import com.universalmedialibrary.services.media.free.FreeMediaType
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FreeMediaScreenModelTest {
+
+    @Test
+    fun toUiModel_usesNullSafeFallbacks_whenOptionalFieldsAreMissing() {
+        val item = FreeMediaItem(
+            id = "missing-optionals",
+            type = FreeMediaType.FEATURE_FILM,
+            source = FreeMediaSource.INTERNET_ARCHIVE,
+            title = "Untitled Test Movie",
+            thumbnailUrl = null,
+            runtimeSeconds = null,
+            year = null
+        )
+
+        val uiModel = item.toUiModel()
+
+        assertNull(uiModel.thumbnailUrl)
+        assertEquals("Year unknown", uiModel.yearLabel)
+        assertEquals("Duration unknown", uiModel.durationLabel)
+    }
+
+    @Test
+    fun freeMediaItemKey_fallsBackToDeterministicKey_whenIdIsBlank() {
+        val item = FreeMediaItem(
+            id = " ",
+            type = FreeMediaType.NATIONAL_SCREENING_ROOM,
+            source = FreeMediaSource.LIBRARY_OF_CONGRESS,
+            title = "Sample Record",
+            year = null
+        )
+
+        val keyAtFirstIndex = freeMediaItemKey(item = item, index = 0)
+        val keyAtSecondIndex = freeMediaItemKey(item = item, index = 1)
+
+        assertEquals("NATIONAL_SCREENING_ROOM:Sample Record:unknown-year:0", keyAtFirstIndex)
+        assertNotEquals(keyAtFirstIndex, keyAtSecondIndex)
+    }
+}


### PR DESCRIPTION
### Motivation
- Improve observability by logging full throwable details when `loadMedia()` fails so crashes can be diagnosed with context.
- Prevent Compose crashes and unstable composition caused by missing/blank optional fields (`thumbnailUrl`, `runtimeSeconds`, `year`) and blank IDs in the free media list.
- Skills used: no session skills were required; changes were implemented directly against the codebase.

### Description
- Add structured `AppLogger.error(...)` in `FreeMediaViewModel.loadMedia()` that includes the full `throwable` and contextual fields `activeType` and `query` before the view state error is updated.
- Introduce a null-safe mapping `FreeMediaItem.toUiModel()` that provides `thumbnailUrl` normalization, `yearLabel` defaulting to `"Year unknown"`, and `durationLabel` defaulting to `"Duration unknown"` (with a humanized format for positive runtimes).
- Replace `LazyColumn` `items(...)` usage with `itemsIndexed(...)` and a guarded `freeMediaItemKey(...)` that uses `id` when available and otherwise falls back to a deterministic key derived from title, year, and index.
- Add `FreeMediaScreenModelTest` covering a record with missing optional fields and a blank `id` to assert the UI model fallbacks and key fallback behavior.

### Testing
- Added unit test `com.universalmedialibrary.ui.media.FreeMediaScreenModelTest` and attempted to run `./gradlew :CleverFerret:test --tests com.universalmedialibrary.ui.media.FreeMediaScreenModelTest` in the environment.
- The test run failed in this environment due to an unsupported Java runtime (detected JDK 25 while the project requires JDK 17–21), so no tests completed successfully here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c69d2d2c8323bbfe7c660db501bc)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the free media UI by adding comprehensive null safety handling for optional fields (`thumbnailUrl`, `year`, `runtimeSeconds`) and blank IDs in the media catalog, preventing Compose crashes from unstable keys. It introduces a `toUiModel()` mapping function that provides sensible fallback labels ("Year unknown", "Duration unknown") and normalizes thumbnail URLs. The PR also improves crash diagnostics by adding structured error logging with full throwable details and contextual information (`activeType`, `query`) when media loading fails. A key generation fallback mechanism using `freeMediaItemKey()` ensures stable Compose list rendering even when IDs are blank. Unit tests validate the null-safe transformations and key fallback behavior.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/src/test/java/com/universalmedialibrary/ui/media/FreeMediaScreenModelTest.kt` |
| 2 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/media/FreeMediaViewModel.kt` |
| 3 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/media/FreeMediaScreen.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->