### PR TITLE
Use canonical MediaType parsing for MediaOpenScreen routing

### DIFF
--- a/CleverFerret/src/main/java/com/universalmedialibrary/data/MediaType.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/data/MediaType.kt
@@ -34,6 +34,40 @@ enum class MediaType {
     UNKNOWN
 }
 
+fun String.toMediaTypeOrUnknown(): MediaType {
+    val normalized = trim().uppercase()
+    return when (normalized) {
+        "TV_EPISODE" -> MediaType.TV_SHOW
+        else -> MediaType.entries.firstOrNull { it.name == normalized } ?: MediaType.UNKNOWN
+    }
+}
+
+fun MediaType.isAudioType(): Boolean {
+    return when (this) {
+        MediaType.AUDIO,
+        MediaType.AUDIOBOOK,
+        MediaType.MUSIC,
+        MediaType.MUSIC_TRACK,
+        MediaType.MUSIC_ALBUM,
+        MediaType.PODCAST,
+        MediaType.PODCAST_EPISODE,
+        MediaType.PODCAST_SERIES,
+        MediaType.RADIO,
+        MediaType.MIDI -> true
+        else -> false
+    }
+}
+
+fun MediaType.isVideoType(): Boolean {
+    return when (this) {
+        MediaType.MOVIE,
+        MediaType.TV_SHOW,
+        MediaType.DOCUMENTARY,
+        MediaType.VIDEO -> true
+        else -> false
+    }
+}
+
 // Extension functions for MediaType
 fun MediaType.getDisplayName(): String {
     return when (this) {

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/open/MediaOpenScreen.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/open/MediaOpenScreen.kt
@@ -7,9 +7,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.universalmedialibrary.data.isAudioType
+import com.universalmedialibrary.data.isVideoType
+import com.universalmedialibrary.data.toMediaTypeOrUnknown
 import com.universalmedialibrary.ui.reader.EReaderScreen
 import com.universalmedialibrary.ui.reader.DocumentReaderScreen
 import com.universalmedialibrary.ui.reader.ComicReaderScreen
@@ -21,6 +23,35 @@ private val AUDIO_EXTENSIONS = setOf(
 private val VIDEO_EXTENSIONS = setOf(
     "mp4", "mkv", "avi", "mov", "wmv", "flv", "webm", "m4v", "3gp"
 )
+
+internal enum class OpenViewerTarget {
+    EBOOK,
+    DOCUMENT,
+    COMIC,
+    AUDIO,
+    VIDEO,
+    NONE
+}
+
+internal fun resolveViewerTarget(
+    fileExtension: String,
+    fileName: String,
+    mediaTypeRaw: String
+): OpenViewerTarget {
+    val ext = fileExtension.lowercase().ifBlank {
+        fileName.substringAfterLast('.', "").lowercase()
+    }
+    val mediaType = mediaTypeRaw.toMediaTypeOrUnknown()
+
+    return when {
+        ext == "epub" -> OpenViewerTarget.EBOOK
+        ext in setOf("pdf", "txt", "html", "htm", "docx") -> OpenViewerTarget.DOCUMENT
+        ext in setOf("cbz", "cbr") -> OpenViewerTarget.COMIC
+        ext in AUDIO_EXTENSIONS || mediaType.isAudioType() -> OpenViewerTarget.AUDIO
+        ext in VIDEO_EXTENSIONS || mediaType.isVideoType() -> OpenViewerTarget.VIDEO
+        else -> OpenViewerTarget.NONE
+    }
+}
 
 @Composable
 fun MediaOpenScreen(
@@ -38,21 +69,17 @@ fun MediaOpenScreen(
             val item = uiState.mediaItem!!
             val path = item.filePath
             val name = item.fileName
-            
-            // Use the dedicated fileExtension field first, then fall back to parsing fileName
-            val ext = item.fileExtension.lowercase().ifBlank {
-                name.substringAfterLast('.', "").lowercase()
-            }
-            
-            // Also check mediaType for audio/video content (handles streams without extensions)
-            val isAudioByType = item.mediaType.uppercase() in setOf("MUSIC_TRACK", "AUDIO", "PODCAST", "PODCAST_EPISODE", "AUDIOBOOK")
-            val isVideoByType = item.mediaType.uppercase() in setOf("MOVIE", "TV_SHOW", "TV_EPISODE", "VIDEO")
-            
-            when {
-                ext == "epub" -> EReaderScreen(bookFilePath = path, onBack = onBack)
-                ext in setOf("pdf", "txt", "html", "htm", "docx") -> DocumentReaderScreen(uriString = path, fileName = name, onBack = onBack)
-                ext in setOf("cbz", "cbr") -> ComicReaderScreen(uriString = path, fileName = name, onBack = onBack)
-                ext in AUDIO_EXTENSIONS || isAudioByType -> {
+            val viewerTarget = resolveViewerTarget(
+                fileExtension = item.fileExtension,
+                fileName = name,
+                mediaTypeRaw = item.mediaType
+            )
+
+            when (viewerTarget) {
+                OpenViewerTarget.EBOOK -> EReaderScreen(bookFilePath = path, onBack = onBack)
+                OpenViewerTarget.DOCUMENT -> DocumentReaderScreen(uriString = path, fileName = name, onBack = onBack)
+                OpenViewerTarget.COMIC -> ComicReaderScreen(uriString = path, fileName = name, onBack = onBack)
+                OpenViewerTarget.AUDIO -> {
                     // Start audio playback and show a simple player UI
                     LaunchedEffect(item) {
                         viewModel.playAudioFile(item)
@@ -63,7 +90,7 @@ fun MediaOpenScreen(
                         onBack = onBack
                     )
                 }
-                ext in VIDEO_EXTENSIONS || isVideoByType -> {
+                OpenViewerTarget.VIDEO -> {
                     // Video files - start video playback
                     LaunchedEffect(item) {
                         viewModel.playVideoFile(item)
@@ -77,7 +104,10 @@ fun MediaOpenScreen(
                         Text("Starting playback...")
                     }
                 }
-                else -> {
+                OpenViewerTarget.NONE -> {
+                    val ext = item.fileExtension.lowercase().ifBlank {
+                        name.substringAfterLast('.', "").lowercase()
+                    }
                     // Show more helpful message with mediaType info
                     Column(
                         modifier = Modifier.fillMaxSize().padding(16.dp),

--- a/CleverFerret/src/test/java/com/universalmedialibrary/ui/open/MediaOpenScreenRoutingTest.kt
+++ b/CleverFerret/src/test/java/com/universalmedialibrary/ui/open/MediaOpenScreenRoutingTest.kt
@@ -1,0 +1,44 @@
+package com.universalmedialibrary.ui.open
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class MediaOpenScreenRoutingTest {
+
+    @Test
+    fun resolveViewerTarget_routesMusicTrackToAudio() {
+        val target = resolveViewerTarget(
+            fileExtension = "",
+            fileName = "stream",
+            mediaTypeRaw = "MUSIC_TRACK"
+        )
+
+        assertEquals(OpenViewerTarget.AUDIO, target)
+        assertNotEquals(OpenViewerTarget.NONE, target)
+    }
+
+    @Test
+    fun resolveViewerTarget_routesMusicToAudio() {
+        val target = resolveViewerTarget(
+            fileExtension = "",
+            fileName = "stream",
+            mediaTypeRaw = "MUSIC"
+        )
+
+        assertEquals(OpenViewerTarget.AUDIO, target)
+        assertNotEquals(OpenViewerTarget.NONE, target)
+    }
+
+    @Test
+    fun resolveViewerTarget_routesMusicAlbumToAudio() {
+        val target = resolveViewerTarget(
+            fileExtension = "",
+            fileName = "stream",
+            mediaTypeRaw = "MUSIC_ALBUM"
+        )
+
+        assertEquals(OpenViewerTarget.AUDIO, target)
+        assertNotEquals(OpenViewerTarget.NONE, target)
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace brittle ad-hoc `mediaType.uppercase() in setOf(...)` checks with canonical enum-based parsing so canonical music values (`MUSIC`, `MUSIC_ALBUM`, `MUSIC_TRACK`) are recognized as audio. 
- Centralize media-type classification to reduce duplication and make viewer routing more robust for streams and legacy type strings.

### Description
- Added `String.toMediaTypeOrUnknown()` to parse/normalize raw type strings and handle legacy mappings like `TV_EPISODE` to `TV_SHOW`. 
- Added `MediaType.isAudioType()` and `MediaType.isVideoType()` predicate functions to centralize audio/video classification. 
- Refactored `MediaOpenScreen` to use a new `resolveViewerTarget(...)` function and `OpenViewerTarget` enum so routing uses the canonical `MediaType` predicates instead of brittle string sets. 
- Added unit tests `MediaOpenScreenRoutingTest` that assert `MUSIC_TRACK`, `MUSIC`, and `MUSIC_ALBUM` resolve to audio and do not fall through to the `NONE` (No viewer) path; modified files: `MediaType.kt`, `MediaOpenScreen.kt`, and added `MediaOpenScreenRoutingTest.kt`.

### Testing
- Created unit tests under `CleverFerret/src/test/java/com/universalmedialibrary/ui/open/MediaOpenScreenRoutingTest.kt` covering `MUSIC_TRACK`, `MUSIC`, and `MUSIC_ALBUM`. 
- Attempted to run `:CleverFerret:testDebugUnitTest --tests com.universalmedialibrary.ui.open.MediaOpenScreenRoutingTest`, but the build could not execute in this environment because Android SDK target `android-36` is not installed, so tests were not run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c69d3e348323a281d709f8427719)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors media type handling in `MediaOpenScreen` to use canonical enum-based parsing instead of brittle string comparisons. It introduces helper functions (`toMediaTypeOrUnknown()`, `isAudioType()`, `isVideoType()`) to centralize media classification and adds a `resolveViewerTarget()` function that determines which viewer to route to based on file extension and media type. The changes ensure that canonical music types (`MUSIC`, `MUSIC_ALBUM`, `MUSIC_TRACK`) are properly recognized as audio content and prevent them from falling through to the "No viewer" path. Unit tests verify the routing logic for music-related media types.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/src/main/java/com/universalmedialibrary/data/MediaType.kt` |
| 2 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/open/MediaOpenScreen.kt` |
| 3 | `CleverFerret/src/test/java/com/universalmedialibrary/ui/open/MediaOpenScreenRoutingTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->