### PR TITLE
Filter podcast search results to valid feeds and surface feed validation via snackbar

### DIFF
--- a/CleverFerret/src/main/java/com/universalmedialibrary/services/podcast/PodcastService.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/services/podcast/PodcastService.kt
@@ -24,6 +24,7 @@ import kotlin.text.Charsets
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
+import java.net.URISyntaxException
 import java.net.URL
 import java.security.MessageDigest
 import java.text.SimpleDateFormat
@@ -392,7 +393,7 @@ class PodcastService @Inject constructor(
                     try { resolvedApiKeys["spotify_token"]?.let { allResults.addAll(searchSpotifyPodcasts(query, it)) } } catch (_: Exception) {}
                     try { resolvedApiKeys["taddy"]?.let { allResults.addAll(searchTaddyPodcasts(query, it)) } } catch (_: Exception) {}
                     try { allResults.addAll(searchGPodderPodcasts(query)) } catch (_: Exception) {}
-                    allResults
+                    allResults.filter { hasValidFeedUrl(it.feedUrl) }
                 },
                 parse = { it },
                 deduplicate = { results -> deduplicatePodcastResults(results) },
@@ -492,7 +493,8 @@ class PodcastService @Inject constructor(
     ): List<PodcastSearchResult> {
         val api = credentials?.let { buildPodcastIndexApi(it) } ?: podcastIndexApi
         val response = api.searchPodcasts(query)
-        return response.feeds.map { feed ->
+        return response.feeds.mapNotNull { feed ->
+            val feedUrl = firstValidFeedUrl(feed.url, feed.originalUrl) ?: return@mapNotNull null
             val newestEpisodeDate = feed.newestItemPubdate?.let { it * 1000 }
             val funding = feed.funding.orEmpty().mapNotNull { fundingItem ->
                 val url = fundingItem.url?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
@@ -525,7 +527,7 @@ class PodcastService @Inject constructor(
                 title = feed.title,
                 author = feed.author.ifEmpty { feed.ownerName },
                 description = feed.description,
-                feedUrl = feed.url,
+                feedUrl = feedUrl,
                 imageUrl = feed.image.ifEmpty { feed.artwork },
                 episodeCount = feed.episodeCount,
                 category = feed.categories.values.firstOrNull(),
@@ -541,13 +543,14 @@ class PodcastService @Inject constructor(
 
     private suspend fun searchiTunesPodcasts(query: String): List<PodcastSearchResult> {
         val response = applePodcastsApi.searchPodcasts(query)
-        return response.results.map { podcast ->
+        return response.results.mapNotNull { podcast ->
+            val feedUrl = podcast.feedUrl.toValidFeedUrlOrNull() ?: return@mapNotNull null
             PodcastSearchResult(
                 id = "itunes_${podcast.trackId}",
                 title = podcast.trackName,
                 author = podcast.artistName,
                 description = podcast.collectionName ?: "",
-                feedUrl = podcast.feedUrl,
+                feedUrl = feedUrl,
                 imageUrl = podcast.artworkUrl600
                     ?: podcast.artworkUrl100
                     ?: podcast.artworkUrl60
@@ -578,13 +581,14 @@ class PodcastService @Inject constructor(
             .create(ListenNotesApi::class.java)
 
         val response = apiWithAuth.searchPodcasts(query)
-        return response.results.map { podcast ->
+        return response.results.mapNotNull { podcast ->
+            val feedUrl = podcast.rss.toValidFeedUrlOrNull() ?: return@mapNotNull null
             PodcastSearchResult(
                 id = "ln_${podcast.id}",
                 title = podcast.title,
                 author = podcast.publisher,
                 description = podcast.description,
-                feedUrl = podcast.rss,
+                feedUrl = feedUrl,
                 imageUrl = podcast.image,
                 episodeCount = podcast.total_episodes,
                 category = podcast.genres.firstOrNull()?.name,
@@ -595,32 +599,20 @@ class PodcastService @Inject constructor(
     }
 
     private suspend fun searchSpotifyPodcasts(query: String, token: String): List<PodcastSearchResult> {
-        val response = spotifyApi.searchPodcasts(query, authorization = "Bearer $token")
-        return response.shows.items.map { show ->
-            PodcastSearchResult(
-                id = "spotify_${show.id}",
-                title = show.name,
-                author = show.publisher,
-                description = show.description,
-                feedUrl = "", // Spotify doesn't provide RSS feeds
-                imageUrl = show.images.firstOrNull()?.url,
-                episodeCount = show.total_episodes,
-                category = null,
-                lastEpisodeDate = null,
-                source = "spotify"
-            )
-        }
+        spotifyApi.searchPodcasts(query, authorization = "Bearer $token")
+        return emptyList() // Spotify doesn't expose RSS feeds for direct subscription.
     }
 
     private suspend fun searchTaddyPodcasts(query: String, apiKey: String): List<PodcastSearchResult> {
         val response = taddyApi.searchPodcasts(query, apiKey = apiKey)
-        return response.results.map { podcast ->
+        return response.results.mapNotNull { podcast ->
+            val feedUrl = podcast.feedUrl.toValidFeedUrlOrNull() ?: return@mapNotNull null
             PodcastSearchResult(
                 id = "taddy_${podcast.uuid}",
                 title = podcast.name,
                 author = podcast.author,
                 description = podcast.description,
-                feedUrl = podcast.feedUrl,
+                feedUrl = feedUrl,
                 imageUrl = podcast.imageUrl,
                 episodeCount = podcast.episodeCount,
                 category = podcast.categories.firstOrNull(),
@@ -633,7 +625,7 @@ class PodcastService @Inject constructor(
     private suspend fun searchGPodderPodcasts(query: String): List<PodcastSearchResult> {
         val response = gPodderApi.searchPodcasts(query)
         return response.mapNotNull { podcast ->
-            val feedUrl = podcast.url?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+            val feedUrl = podcast.url.toValidFeedUrlOrNull() ?: return@mapNotNull null
             val descriptionBuilder = StringBuilder()
             if (!podcast.description.isNullOrBlank()) {
                 descriptionBuilder.append(podcast.description.trim())
@@ -662,7 +654,7 @@ class PodcastService @Inject constructor(
 
     private fun deduplicatePodcastResults(results: List<PodcastSearchResult>): List<PodcastSearchResult> {
         // Group by feed URL first (most accurate)
-        val byFeedUrl = results.groupBy { it.feedUrl.lowercase() }
+        val byFeedUrl = results.groupBy { it.feedUrl.trim().lowercase() }
         val deduplicated = mutableListOf<PodcastSearchResult>()
 
         byFeedUrl.forEach { (feedUrl, podcasts) ->
@@ -683,6 +675,24 @@ class PodcastService @Inject constructor(
 
         // Additional deduplication by title similarity for remaining items
         return deduplicated.distinctBy { it.title.lowercase().trim() }
+    }
+
+    private fun hasValidFeedUrl(feedUrl: String?): Boolean = feedUrl.toValidFeedUrlOrNull() != null
+
+    private fun firstValidFeedUrl(vararg candidates: String?): String? =
+        candidates.firstNotNullOfOrNull { it.toValidFeedUrlOrNull() }
+
+    private fun String?.toValidFeedUrlOrNull(): String? {
+        val trimmed = this?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        return try {
+            val uri = URI(trimmed)
+            val scheme = uri.scheme?.lowercase(Locale.US)
+            if ((scheme == "http" || scheme == "https") && !uri.host.isNullOrBlank()) trimmed else null
+        } catch (_: URISyntaxException) {
+            null
+        } catch (_: IllegalArgumentException) {
+            null
+        }
     }
 
     /**

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/podcast/PodcastManagerScreen.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/podcast/PodcastManagerScreen.kt
@@ -29,7 +29,7 @@ import com.universalmedialibrary.services.podcast.DownloadStatus
 import com.universalmedialibrary.ui.components.PinAccessDialog
 import com.universalmedialibrary.ui.theme.MetallicFAB
 import com.universalmedialibrary.ui.theme.MetallicTopAppBar
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.collectLatest
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -45,6 +45,13 @@ fun PodcastManagerScreen(
     var showSearchDialog by remember { mutableStateOf(false) }
     var showAddFeedDialog by remember { mutableStateOf(false) }
     var selectedTab by remember { mutableIntStateOf(0) }
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(viewModel) {
+        viewModel.userMessages.collectLatest { message ->
+            snackbarHostState.showSnackbar(message)
+        }
+    }
 
     Scaffold(
         topBar = {
@@ -80,7 +87,10 @@ fun PodcastManagerScreen(
                     Icon(Icons.Default.Add, contentDescription = "Add Podcast")
                 }
             )
-        }
+        },
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
+        },
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -195,8 +205,11 @@ fun PodcastManagerScreen(
                 viewModel.searchPodcasts(query)
             },
             onSubscribe = { podcast ->
-                viewModel.subscribeFromSearchResult(podcast)
-                showSearchDialog = false
+                viewModel.subscribeFromSearchResult(podcast) { subscribed ->
+                    if (subscribed) {
+                        showSearchDialog = false
+                    }
+                }
             }
         )
     }

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/podcast/PodcastViewModel.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/podcast/PodcastViewModel.kt
@@ -14,6 +14,8 @@ import com.universalmedialibrary.ui.components.pin.PinChallenge
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import java.net.URI
+import java.net.URISyntaxException
 import java.io.File
 import javax.inject.Inject
 
@@ -28,6 +30,8 @@ class PodcastViewModel @Inject constructor(
     val uiState: StateFlow<PodcastUiState> = _uiState.asStateFlow()
     private val _pendingPinChallenge = MutableStateFlow<PinChallenge?>(null)
     val pendingPinChallenge: StateFlow<PinChallenge?> = _pendingPinChallenge.asStateFlow()
+    private val _userMessages = MutableSharedFlow<String>(extraBufferCapacity = 1)
+    val userMessages: SharedFlow<String> = _userMessages.asSharedFlow()
     private var pendingPinAction: (() -> Unit)? = null
 
     init {
@@ -47,7 +51,7 @@ class PodcastViewModel @Inject constructor(
             try {
                 val results = repository.searchPodcastsOnline(query)
                 _uiState.value = _uiState.value.copy(
-                    searchResults = results,
+                    searchResults = results.filter { it.feedUrl.isValidFeedUrl() },
                     isSearching = false,
                     error = null
                 )
@@ -60,16 +64,20 @@ class PodcastViewModel @Inject constructor(
         }
     }
 
-    fun subscribeFromSearchResult(searchResult: PodcastSearchResult) {
+    fun subscribeFromSearchResult(
+        searchResult: PodcastSearchResult,
+        onComplete: (Boolean) -> Unit = {}
+    ) {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
 
             // Validate feedUrl before attempting to subscribe
-            if (searchResult.feedUrl.isBlank()) {
+            if (!searchResult.feedUrl.isValidFeedUrl()) {
                 _uiState.value = _uiState.value.copy(
-                    isLoading = false,
-                    error = "Cannot subscribe: Feed URL is missing for this podcast"
+                    isLoading = false
                 )
+                _userMessages.tryEmit("Cannot subscribe: this result is missing a valid feed URL.")
+                onComplete(false)
                 return@launch
             }
 
@@ -80,6 +88,8 @@ class PodcastViewModel @Inject constructor(
                             isLoading = false,
                             error = null
                         )
+                        _userMessages.tryEmit("Subscribed to ${searchResult.title}")
+                        onComplete(true)
                         // Podcasts will be reloaded automatically via Flow
                     }
                     is PodcastOperationResult.Error -> {
@@ -87,6 +97,8 @@ class PodcastViewModel @Inject constructor(
                             isLoading = false,
                             error = result.message
                         )
+                        _userMessages.tryEmit(result.message)
+                        onComplete(false)
                     }
                 }
             } catch (e: kotlinx.coroutines.CancellationException) {
@@ -96,6 +108,8 @@ class PodcastViewModel @Inject constructor(
                     isLoading = false,
                     error = "Subscription failed: ${e.message}"
                 )
+                _userMessages.tryEmit("Subscription failed: ${e.message}")
+                onComplete(false)
             }
         }
     }
@@ -392,6 +406,20 @@ class PodcastViewModel @Inject constructor(
                 playbackFailureReason = failureReason
             )
         }
+    }
+}
+
+private fun String.isValidFeedUrl(): Boolean {
+    val trimmed = trim()
+    if (trimmed.isEmpty()) return false
+    return try {
+        val uri = URI(trimmed)
+        val scheme = uri.scheme?.lowercase()
+        (scheme == "http" || scheme == "https") && !uri.host.isNullOrBlank()
+    } catch (_: URISyntaxException) {
+        false
+    } catch (_: IllegalArgumentException) {
+        false
     }
 }
 

--- a/CleverFerret/src/test/java/com/universalmedialibrary/ui/podcast/PodcastViewModelTest.kt
+++ b/CleverFerret/src/test/java/com/universalmedialibrary/ui/podcast/PodcastViewModelTest.kt
@@ -1,0 +1,108 @@
+package com.universalmedialibrary.ui.podcast
+
+import com.google.common.truth.Truth.assertThat
+import com.universalmedialibrary.data.repository.podcast.PodcastRepository
+import com.universalmedialibrary.services.DownloadSafetyChecker
+import com.universalmedialibrary.services.podcast.PodcastDownloadManager
+import com.universalmedialibrary.services.podcast.PodcastSearchResult
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PodcastViewModelTest {
+
+    @MockK
+    lateinit var repository: PodcastRepository
+
+    @MockK
+    lateinit var downloadManager: PodcastDownloadManager
+
+    @MockK
+    lateinit var downloadSafetyChecker: DownloadSafetyChecker
+
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var viewModel: PodcastViewModel
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        Dispatchers.setMain(dispatcher)
+
+        every { repository.getSubscribedPodcasts() } returns flowOf(emptyList())
+        every { repository.getDownloadedEpisodes() } returns flowOf(emptyList())
+        every { downloadManager.downloadProgress } returns MutableStateFlow(emptyMap())
+
+        viewModel = PodcastViewModel(
+            repository = repository,
+            downloadManager = downloadManager,
+            downloadSafetyChecker = downloadSafetyChecker
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `searchPodcasts excludes results without valid feed URL`() = runTest {
+        coEvery { repository.searchPodcastsOnline("android") } returns listOf(
+            searchResult(id = "valid", feedUrl = "https://example.com/feed.xml"),
+            searchResult(id = "blank", feedUrl = "  "),
+            searchResult(id = "invalid", feedUrl = "not-a-url")
+        )
+
+        viewModel.searchPodcasts("android")
+        advanceUntilIdle()
+
+        val resultIds = viewModel.uiState.value.searchResults.map { it.id }
+        assertThat(resultIds).containsExactly("valid")
+    }
+
+    @Test
+    fun `subscribeFromSearchResult with blank feed emits snackbar message and skips modal error`() = runTest {
+        val message = async { viewModel.userMessages.first() }
+        var callbackResult: Boolean? = null
+
+        viewModel.subscribeFromSearchResult(searchResult(id = "blank", feedUrl = "")) {
+            callbackResult = it
+        }
+        advanceUntilIdle()
+
+        assertThat(message.await()).isEqualTo("Cannot subscribe: this result is missing a valid feed URL.")
+        assertThat(viewModel.uiState.value.error).isNull()
+        assertThat(viewModel.uiState.value.isLoading).isFalse()
+        assertThat(callbackResult).isFalse()
+        coVerify(exactly = 0) { repository.subscribeToPodcast(any()) }
+    }
+
+    private fun searchResult(id: String, feedUrl: String) = PodcastSearchResult(
+        id = id,
+        title = "Podcast $id",
+        description = null,
+        author = null,
+        imageUrl = null,
+        feedUrl = feedUrl,
+        category = null,
+        episodeCount = null,
+        lastEpisodeDate = null,
+        source = "test"
+    )
+}


### PR DESCRIPTION
### Motivation
- Prevent showing/subscribing to search results that cannot produce a valid RSS/HTTP(S) feed URL (e.g., Spotify entries), and prefer valid feed sources when multiple candidates exist.
- Convert feed-validation failures during subscription from a blocking/modal error to inline/snackbar user feedback so the search dialog is not interrupted by invalid results.
- Add automated coverage for malformed/blank feed URL cases to protect against regressions in search/subscription flows.

### Description
- In `PodcastService` added feed-url normalization and validation helpers (`toValidFeedUrlOrNull`, `firstValidFeedUrl`, `hasValidFeedUrl`) and applied them across search integrations so only results with valid `http`/`https` feed URLs are emitted; `PodcastIndex` now falls back to `originalUrl` when available and `Spotify` no longer returns subscribable entries. (`services/podcast/PodcastService.kt`).
- In `PodcastViewModel` added a `MutableSharedFlow<String>` `userMessages` to emit non-modal feedback, filtered `searchResults` to exclude invalid feed URLs, and changed `subscribeFromSearchResult` to emit snackbar messages and return completion via a callback instead of setting a blocking modal `error`. (`ui/podcast/PodcastViewModel.kt`).
- In `PodcastManagerScreen` wired a `SnackbarHost` and collect from `viewModel.userMessages` to show inline/snackbar feedback, and only dismiss the search dialog when a subscription actually succeeds. (`ui/podcast/PodcastManagerScreen.kt`).
- Added unit tests in `src/test/java/com/universalmedialibrary/ui/podcast/PodcastViewModelTest.kt` that verify search filtering of blank/malformed feed URLs and that an invalid subscribe attempt emits a user message and does not call the repository.

### Testing
- Added unit tests targeting `PodcastViewModel` (`PodcastViewModelTest`) that cover: (1) exclusion of blank/malformed `feedUrl` entries from `searchResults`, and (2) non-modal snackbar feedback when subscribing from a search result with an invalid feed; these tests are included in the repo under `src/test`.
- Attempted to run the new unit tests with `./gradlew :CleverFerret:testDebugUnitTest --tests com.universalmedialibrary.ui.podcast.PodcastViewModelTest`, but execution failed in this environment due to an unsupported Java runtime (openjdk 25) while the project requires JDK 17–21, so tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c6a9df888323b05932e1bd312845)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves the podcast search and subscription experience by filtering out invalid RSS feed URLs (such as Spotify entries that don't provide direct feeds) and replacing blocking error modals with non-intrusive snackbar notifications. It introduces feed URL validation helpers that check for valid `http`/`https` schemes across multiple search providers (PodcastIndex, iTunes, ListenNotes, Taddy, and gPodder), updates the ViewModel to emit user messages via a `SharedFlow` instead of setting modal errors, and wires a `SnackbarHost` in the UI to display these messages inline. Unit tests are added to verify that search results exclude blank or malformed feed URLs and that invalid subscription attempts trigger snackbar feedback without calling the repository.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/src/test/java/com/universalmedialibrary/ui/podcast/PodcastViewModelTest.kt` |
| 2 | `CleverFerret/src/main/java/com/universalmedialibrary/services/podcast/PodcastService.kt` |
| 3 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/podcast/PodcastViewModel.kt` |
| 4 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/podcast/PodcastManagerScreen.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->