### PR TITLE
Harden OPDS feed handling and add "Report feed" diagnostics

### DIFF
--- a/CleverFerret/src/main/java/com/universalmedialibrary/services/opds/OPDSClient.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/services/opds/OPDSClient.kt
@@ -1,6 +1,7 @@
 package com.universalmedialibrary.services.opds
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
@@ -8,8 +9,8 @@ import okhttp3.Request
 import okhttp3.Response
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
-import java.io.InputStream
 import java.io.IOException
+import java.io.InputStream
 import java.io.StringReader
 import java.net.URLEncoder
 import javax.inject.Inject
@@ -31,21 +32,69 @@ class OPDSClient @Inject constructor(
 ) {
 
     suspend fun fetchFeed(url: String): OPDSFeed = withContext(Dispatchers.IO) {
-        try {
-            val request = Request.Builder()
-                .url(url)
-                .header("User-Agent", USER_AGENT)
-                .build()
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", USER_AGENT)
+            .build()
 
+        executeWithRetry(url) {
             okHttpClient.newCall(request).execute().use { response ->
                 ensureSuccess(response)
                 response.body?.byteStream()?.use { stream ->
-                    parseFeed(stream, url)
+                    try {
+                        parseFeed(stream, url)
+                    } catch (parseError: IllegalStateException) {
+                        throw parseError
+                    } catch (parseError: Exception) {
+                        throw IllegalStateException(
+                            "Malformed OPDS feed at '$url': ${parseError.message ?: "unable to parse XML"}",
+                            parseError
+                        )
+                    }
                 } ?: throw IllegalStateException("Empty OPDS response body")
             }
-        } catch (e: IOException) {
-            throw IllegalStateException("Unable to reach OPDS server. Check network connectivity and try again.", e)
         }
+    }
+
+    private suspend fun <T> executeWithRetry(url: String, block: () -> T): T {
+        var attempt = 0
+        var lastError: Throwable? = null
+
+        while (attempt < MAX_RETRY_ATTEMPTS) {
+            attempt += 1
+            try {
+                return block()
+            } catch (error: Throwable) {
+                lastError = error
+                val shouldRetry = shouldRetryTransient(error) && attempt < MAX_RETRY_ATTEMPTS
+                if (!shouldRetry) {
+                    throw when (error) {
+                        is IOException -> IllegalStateException(
+                            "Unable to reach OPDS server after $attempt attempt(s): $url",
+                            error
+                        )
+                        else -> error
+                    }
+                }
+
+                delay(calculateBackoffMillis(attempt))
+            }
+        }
+
+        throw IllegalStateException("Unable to reach OPDS server: $url", lastError)
+    }
+
+    private fun shouldRetryTransient(error: Throwable): Boolean {
+        return when (error) {
+            is TransientHttpException -> true
+            is IOException -> true
+            else -> false
+        }
+    }
+
+    private fun calculateBackoffMillis(attempt: Int): Long {
+        val exponent = (attempt - 1).coerceAtLeast(0)
+        return INITIAL_BACKOFF_MS * (1L shl exponent)
     }
 
     private fun ensureSuccess(response: Response) {
@@ -56,6 +105,10 @@ class OPDSClient @Inject constructor(
                 404 -> "Catalog/feed not found (HTTP 404)."
                 else -> "OPDS request failed: HTTP ${response.code} ${response.message}"
             }
+
+            if (response.code in RETRYABLE_HTTP_CODES) {
+                throw TransientHttpException(response.code, reason)
+            }
             throw IllegalStateException(reason)
         }
     }
@@ -65,7 +118,7 @@ class OPDSClient @Inject constructor(
         // (e.g., unescaped & characters in Internet Archive feeds)
         val rawContent = stream.bufferedReader().use { it.readText() }
         val sanitizedContent = sanitizeXmlEntities(rawContent)
-        
+
         val parser = XmlPullParserFactory.newInstance().apply {
             isNamespaceAware = true
         }.newPullParser().apply {
@@ -253,9 +306,14 @@ class OPDSClient @Inject constructor(
         }
     }
 
+    private class TransientHttpException(val statusCode: Int, message: String) : IOException(message)
+
     companion object {
         private const val USER_AGENT = "CleverFerret/1.0 (OPDSClient)"
-        
+        private const val MAX_RETRY_ATTEMPTS = 3
+        private const val INITIAL_BACKOFF_MS = 250L
+        private val RETRYABLE_HTTP_CODES = setOf(408, 429, 500, 502, 503, 504)
+
         /**
          * Regex to match ampersands that are NOT part of valid XML entity references.
          * Valid entities are: &amp; &lt; &gt; &quot; &apos; or numeric refs like &#123; or &#x1F;
@@ -264,16 +322,21 @@ class OPDSClient @Inject constructor(
         private val INVALID_AMPERSAND_REGEX = Regex(
             "&(?!(amp|lt|gt|quot|apos|#\\d+|#x[0-9a-fA-F]+);)"
         )
+        private val INVALID_NUMERIC_ENTITY_REGEX = Regex("&#(?!\\d+;|x[0-9a-fA-F]+;)")
+        private val INVALID_NAMED_ENTITY_REGEX = Regex("&([A-Za-z]+)(?!;)")
     }
-    
+
     /**
-     * Sanitizes XML content by escaping unescaped ampersands and other problematic characters.
-     * 
+     * Sanitizes XML content by escaping unescaped ampersands and malformed entity-like tokens.
+     *
      * Some OPDS feeds (notably Internet Archive) contain malformed XML with unescaped
-     * ampersands in URLs or text content, causing "unterminated entity reference" errors.
-     * This function replaces bare '&' characters (not part of valid entities) with '&amp;'.
+     * ampersands in URLs or text content, causing parser failures.
      */
     private fun sanitizeXmlEntities(xmlContent: String): String {
-        return xmlContent.replace(INVALID_AMPERSAND_REGEX, "&amp;")
+        val escapedAmpersands = xmlContent.replace(INVALID_AMPERSAND_REGEX, "&amp;")
+        val fixedNumericEntityPrefixes = escapedAmpersands.replace(INVALID_NUMERIC_ENTITY_REGEX, "&amp;#")
+        return fixedNumericEntityPrefixes.replace(INVALID_NAMED_ENTITY_REGEX) { match ->
+            "&amp;${match.groupValues[1]}"
+        }
     }
 }

--- a/CleverFerret/src/main/java/com/universalmedialibrary/services/opds/OPDSService.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/services/opds/OPDSService.kt
@@ -158,6 +158,10 @@ class OPDSCatalogService @Inject constructor(
         ).result
     }
 
+    fun buildSearchUrl(template: String, query: String): String {
+        return opdsClient.buildSearchUrl(template, query)
+    }
+
     fun getAllCatalogs(): Flow<List<OPDSCatalog>> {
         return catalogDao.getAllCatalogs()
     }

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/opds/OPDSCatalogBrowserScreen.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/opds/OPDSCatalogBrowserScreen.kt
@@ -142,7 +142,8 @@ fun OPDSCatalogBrowserScreen(
                             val error = result.exceptionOrNull()
                             ErrorView(
                                 message = error?.message ?: "Unknown error",
-                                onRetry = { viewModel.refreshFeed() }
+                                onRetry = { viewModel.refreshFeed() },
+                                onReportFeed = { viewModel.reportFeedIssue() }
                             )
                         }
                     }
@@ -473,7 +474,11 @@ private fun LoadingView() {
 }
 
 @Composable
-private fun ErrorView(message: String, onRetry: () -> Unit) {
+private fun ErrorView(
+    message: String,
+    onRetry: () -> Unit,
+    onReportFeed: () -> Unit
+) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
@@ -499,12 +504,24 @@ private fun ErrorView(message: String, onRetry: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
             Spacer(Modifier.height(16.dp))
-            Button(onClick = onRetry) {
-                Text("Retry")
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                Button(onClick = onRetry) {
+                    Text("Retry")
+                }
+                OutlinedButton(onClick = onReportFeed) {
+                    Text("Report feed")
+                }
             }
         }
     }
 }
+
+private data class OPDSFailureContext(
+    val catalogName: String? = null,
+    val requestedUrl: String? = null,
+    val searchQuery: String? = null,
+    val errorMessage: String
+)
 
 @Composable
 private fun AddCatalogDialog(
@@ -610,6 +627,7 @@ class OPDSCatalogBrowserViewModel @Inject constructor(
 
     private val _userMessage = MutableStateFlow<String?>(null)
     val userMessage = _userMessage.asStateFlow()
+    private val _lastFailureContext = MutableStateFlow<OPDSFailureContext?>(null)
 
     init {
         viewModelScope.launch {
@@ -626,6 +644,7 @@ class OPDSCatalogBrowserViewModel @Inject constructor(
         _selectedCatalog.value = null
         _currentFeed.value = null
         _searchQuery.value = ""
+        _lastFailureContext.value = null
     }
 
     fun refreshFeed() {
@@ -633,7 +652,19 @@ class OPDSCatalogBrowserViewModel @Inject constructor(
         
         viewModelScope.launch {
             _currentFeed.value = null // Show loading
-            _currentFeed.value = opdsCatalogService.browseCatalog(catalog)
+            val result = opdsCatalogService.browseCatalog(catalog)
+            _currentFeed.value = result
+            if (result.isSuccess) {
+                _lastFailureContext.value = null
+            } else {
+                val errorMessage = result.exceptionOrNull()?.message ?: "Unknown OPDS failure"
+                _lastFailureContext.value = OPDSFailureContext(
+                    catalogName = catalog.name,
+                    requestedUrl = catalog.url,
+                    searchQuery = _searchQuery.value.takeIf { it.isNotBlank() },
+                    errorMessage = errorMessage
+                )
+            }
         }
     }
 
@@ -643,7 +674,20 @@ class OPDSCatalogBrowserViewModel @Inject constructor(
         
         viewModelScope.launch {
             _currentFeed.value = null
-            _currentFeed.value = opdsCatalogService.searchCatalog(catalog, query)
+            val searchUrl = catalog.searchUrl?.let { opdsCatalogService.buildSearchUrl(it, query) } ?: catalog.url
+            val result = opdsCatalogService.searchCatalog(catalog, query)
+            _currentFeed.value = result
+            if (result.isSuccess) {
+                _lastFailureContext.value = null
+            } else {
+                val errorMessage = result.exceptionOrNull()?.message ?: "Unknown OPDS failure"
+                _lastFailureContext.value = OPDSFailureContext(
+                    catalogName = catalog.name,
+                    requestedUrl = searchUrl,
+                    searchQuery = query,
+                    errorMessage = errorMessage
+                )
+            }
         }
     }
 
@@ -672,11 +716,36 @@ class OPDSCatalogBrowserViewModel @Inject constructor(
             try {
                 val feed = opdsCatalogService.fetchUrl(url)
                 _currentFeed.value = Result.success(feed)
+                _lastFailureContext.value = null
             } catch (e: Exception) {
                 _currentFeed.value = Result.failure(e)
+                _lastFailureContext.value = OPDSFailureContext(
+                    catalogName = _selectedCatalog.value?.name,
+                    requestedUrl = url,
+                    searchQuery = _searchQuery.value.takeIf { it.isNotBlank() },
+                    errorMessage = e.message ?: "Failed to open feed link."
+                )
                 _userMessage.value = e.message ?: "Failed to open feed link."
             }
         }
+    }
+
+    fun reportFeedIssue() {
+        val context = _lastFailureContext.value
+        if (context == null) {
+            _userMessage.value = "No feed failure context available to report yet."
+            return
+        }
+
+        val diagnostic = buildString {
+            append("Report feed diagnostics\n")
+            append("catalog=").append(context.catalogName ?: "(unknown)").append('\n')
+            append("url=").append(context.requestedUrl ?: "(unknown)").append('\n')
+            append("query=").append(context.searchQuery ?: "(none)").append('\n')
+            append("error=").append(context.errorMessage)
+        }
+        android.util.Log.e("OPDSCatalogBrowser", diagnostic)
+        _userMessage.value = "Feed report captured for diagnostics."
     }
 
     fun clearUserMessage() {

--- a/CleverFerret/src/test/java/com/universalmedialibrary/services/opds/OPDSClientTest.kt
+++ b/CleverFerret/src/test/java/com/universalmedialibrary/services/opds/OPDSClientTest.kt
@@ -1,150 +1,148 @@
 package com.universalmedialibrary.services.opds
 
+import kotlinx.coroutines.test.runTest
+import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
 
-/**
- * Unit tests for OPDSClient XML entity sanitization.
- * 
- * Tests verify that malformed XML with unescaped ampersands (common in Internet Archive feeds)
- * is properly sanitized before parsing.
- */
 class OPDSClientTest {
 
-    /**
-     * Regex to match ampersands that are NOT part of valid XML entity references.
-     * Duplicated from OPDSClient for testing purposes.
-     */
-    private val INVALID_AMPERSAND_REGEX = Regex(
-        "&(?!(amp|lt|gt|quot|apos|#\\d+|#x[0-9a-fA-F]+);)"
-    )
-    
-    private fun sanitizeXmlEntities(xmlContent: String): String {
-        return xmlContent.replace(INVALID_AMPERSAND_REGEX, "&amp;")
+    @Test
+    fun `parses fixture with unescaped ampersands and malformed entities`() = runTest {
+        val fixture = loadFixture("internet_archive_malformed_entities.xml")
+        val client = OPDSClient(clientWithScriptedResponses(listOf(response(200, fixture))))
+
+        val feed = client.fetchFeed("https://archive.org/services/opds")
+
+        assertEquals("Internet Archive Books", feed.title)
+        assertEquals(1, feed.entries.size)
+        assertEquals("Alpha & Omega", feed.entries.first().title)
+        assertTrue(feed.entries.first().acquisitionLinks.first().href.contains("foo=1&bar=2"))
     }
 
     @Test
-    fun `sanitize unescaped ampersand in URL`() {
-        val input = """<link href="http://example.com?foo=1&bar=2"/>"""
-        val expected = """<link href="http://example.com?foo=1&amp;bar=2"/>"""
-        assertEquals(expected, sanitizeXmlEntities(input))
+    fun `parses fixture containing orphan numeric entity prefix`() = runTest {
+        val fixture = loadFixture("orphan_numeric_entity.xml")
+        val client = OPDSClient(clientWithScriptedResponses(listOf(response(200, fixture))))
+
+        val feed = client.fetchFeed("https://example.com/opds")
+
+        assertEquals("Malformed Numeric Entity Feed", feed.title)
+        assertEquals(1, feed.entries.size)
+        assertEquals("Entry with &#oops", feed.entries.first().title)
     }
 
     @Test
-    fun `sanitize multiple unescaped ampersands`() {
-        val input = """<link href="http://example.com?a=1&b=2&c=3"/>"""
-        val expected = """<link href="http://example.com?a=1&amp;b=2&amp;c=3"/>"""
-        assertEquals(expected, sanitizeXmlEntities(input))
+    fun `retries transient http failure and succeeds`() = runTest {
+        val attempts = AtomicInteger(0)
+        val client = OPDSClient(
+            OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    val count = attempts.incrementAndGet()
+                    if (count == 1) {
+                        response(503, "Service unavailable", chain.request())
+                    } else {
+                        response(200, minimalFeed("Retry Success"), chain.request())
+                    }
+                }
+                .build()
+        )
+
+        val feed = client.fetchFeed("https://retry.example/opds")
+
+        assertEquals("Retry Success", feed.title)
+        assertEquals(2, attempts.get())
     }
 
     @Test
-    fun `preserve valid amp entity`() {
-        val input = """<title>Tom &amp; Jerry</title>"""
-        assertEquals(input, sanitizeXmlEntities(input))
+    fun `does not retry non transient http failure`() = runTest {
+        val attempts = AtomicInteger(0)
+        val client = OPDSClient(
+            OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    attempts.incrementAndGet()
+                    response(404, "Not Found", chain.request())
+                }
+                .build()
+        )
+
+        val failure = runCatching {
+            client.fetchFeed("https://retry.example/opds")
+        }.exceptionOrNull()
+
+        assertTrue(failure is IllegalStateException)
+        assertTrue(failure?.message?.contains("HTTP 404") == true)
+        assertEquals(1, attempts.get())
     }
 
     @Test
-    fun `preserve valid lt entity`() {
-        val input = """<title>a &lt; b</title>"""
-        assertEquals(input, sanitizeXmlEntities(input))
+    fun `keeps fatal parsing failures explicit without retry`() = runTest {
+        val attempts = AtomicInteger(0)
+        val client = OPDSClient(
+            OkHttpClient.Builder()
+                .addInterceptor { chain ->
+                    attempts.incrementAndGet()
+                    response(200, "<html>not opds</html>", chain.request())
+                }
+                .build()
+        )
+
+        val failure = runCatching {
+            client.fetchFeed("https://retry.example/opds")
+        }.exceptionOrNull()
+
+        assertTrue(failure is IllegalStateException)
+        assertTrue(failure?.message?.contains("Malformed OPDS feed") == true)
+        assertEquals(1, attempts.get())
     }
 
-    @Test
-    fun `preserve valid gt entity`() {
-        val input = """<title>a &gt; b</title>"""
-        assertEquals(input, sanitizeXmlEntities(input))
+    private fun loadFixture(name: String): String {
+        val stream = javaClass.classLoader?.getResourceAsStream("opds/$name")
+            ?: error("Missing fixture: $name")
+        return stream.bufferedReader().use { it.readText() }
     }
 
-    @Test
-    fun `preserve valid quot entity`() {
-        val input = """<title>Say &quot;Hello&quot;</title>"""
-        assertEquals(input, sanitizeXmlEntities(input))
+    private fun clientWithScriptedResponses(responses: List<Response>): OkHttpClient {
+        val index = AtomicInteger(0)
+        return OkHttpClient.Builder()
+            .addInterceptor(Interceptor { chain ->
+                val i = index.getAndIncrement().coerceAtMost(responses.lastIndex)
+                val source = responses[i]
+                source.newBuilder().request(chain.request()).build()
+            })
+            .build()
     }
 
-    @Test
-    fun `preserve valid apos entity`() {
-        val input = """<title>It&apos;s fine</title>"""
-        assertEquals(input, sanitizeXmlEntities(input))
-    }
+    private fun minimalFeed(title: String): String = """
+        <?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom">
+            <title>$title</title>
+            <entry>
+                <title>Book</title>
+                <link rel="http://opds-spec.org/acquisition" href="https://example.com/book.epub" type="application/epub+zip"/>
+            </entry>
+        </feed>
+    """.trimIndent()
 
-    @Test
-    fun `preserve numeric entity decimal`() {
-        val input = """<title>&#169; Copyright</title>"""
-        assertEquals(input, sanitizeXmlEntities(input))
-    }
-
-    @Test
-    fun `preserve numeric entity hexadecimal`() {
-        val input = """<title>&#x00A9; Copyright</title>"""
-        assertEquals(input, sanitizeXmlEntities(input))
-    }
-
-    @Test
-    fun `sanitize mixed valid and invalid entities`() {
-        val input = """<content>Tom &amp; Jerry visit http://foo.com?x=1&y=2 &lt;together&gt;</content>"""
-        val expected = """<content>Tom &amp; Jerry visit http://foo.com?x=1&amp;y=2 &lt;together&gt;</content>"""
-        assertEquals(expected, sanitizeXmlEntities(input))
-    }
-
-    @Test
-    fun `sanitize Internet Archive style malformed URL`() {
-        // This simulates the kind of malformed XML that Internet Archive OPDS feeds return
-        val input = """<link href="https://archive.org/services/opds?search=foo&page=1"/>"""
-        val expected = """<link href="https://archive.org/services/opds?search=foo&amp;page=1"/>"""
-        assertEquals(expected, sanitizeXmlEntities(input))
-    }
-
-    @Test
-    fun `sanitize content with ampersand at end of text`() {
-        val input = """<title>Barnes & Noble Books</title>"""
-        val expected = """<title>Barnes &amp; Noble Books</title>"""
-        assertEquals(expected, sanitizeXmlEntities(input))
-    }
-
-    @Test
-    fun `handle empty string`() {
-        assertEquals("", sanitizeXmlEntities(""))
-    }
-
-    @Test
-    fun `handle string with no ampersands`() {
-        val input = """<title>Simple Title</title>"""
-        assertEquals(input, sanitizeXmlEntities(input))
-    }
-
-    @Test
-    fun `preserve valid OPDS feed with properly escaped entities`() {
-        val validFeed = """<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <title>Test &amp; Catalog</title>
-  <entry>
-    <title>Book Title</title>
-    <link href="http://example.com/book?id=1&amp;format=epub"/>
-  </entry>
-</feed>"""
-        assertEquals(validFeed, sanitizeXmlEntities(validFeed))
-    }
-
-    @Test
-    fun `fix malformed OPDS feed with unescaped ampersands`() {
-        val malformedFeed = """<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <title>Test & Catalog</title>
-  <entry>
-    <title>Book Title</title>
-    <link href="http://example.com/book?id=1&format=epub"/>
-  </entry>
-</feed>"""
-        val expectedFeed = """<?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-  <title>Test &amp; Catalog</title>
-  <entry>
-    <title>Book Title</title>
-    <link href="http://example.com/book?id=1&amp;format=epub"/>
-  </entry>
-</feed>"""
-        assertEquals(expectedFeed, sanitizeXmlEntities(malformedFeed))
+    private fun response(
+        code: Int,
+        body: String,
+        request: Request = Request.Builder().url("https://example.com").build()
+    ): Response {
+        return Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message(if (code in 200..299) "OK" else "Error")
+            .body(body.toResponseBody("application/atom+xml".toMediaType()))
+            .build()
     }
 }

--- a/CleverFerret/src/test/resources/opds/internet_archive_malformed_entities.xml
+++ b/CleverFerret/src/test/resources/opds/internet_archive_malformed_entities.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Internet Archive Books</title>
+  <entry>
+    <title>Alpha & Omega</title>
+    <summary>Read this at https://archive.org/details/sample?foo=1&bar=2 and enjoy</summary>
+    <link rel="http://opds-spec.org/acquisition" href="https://archive.org/download/sample.epub?foo=1&bar=2" type="application/epub+zip" />
+  </entry>
+</feed>

--- a/CleverFerret/src/test/resources/opds/orphan_numeric_entity.xml
+++ b/CleverFerret/src/test/resources/opds/orphan_numeric_entity.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Malformed Numeric Entity Feed</title>
+  <entry>
+    <title>Entry with &#oops</title>
+    <summary>Contains orphan numeric marker and invalid named entity &notterminated in text</summary>
+    <link rel="http://opds-spec.org/acquisition" href="https://example.com/book.epub?x=1&y=2" type="application/epub+zip" />
+  </entry>
+</feed>


### PR DESCRIPTION
### Motivation
- Real-world OPDS feeds contain malformed XML entity edge cases and transient HTTP failures which caused parser errors or noisy user-facing failures, and operators need an easy way to capture feed diagnostics for triage. 

### Description
- Extend XML sanitization in `OPDSClient` to escape orphan numeric/entity-like tokens and malformed named-entity prefixes in addition to bare ampersands. 
- Add retry-with-exponential-backoff around OPDS fetches for transient transport/server failures (retryable HTTP codes + `IOException`) while keeping parser exceptions explicit (do not retry fatal parse failures). 
- Surface a `Report feed` action in the OPDS error UI and capture structured failure context (catalog name, requested URL, search query, error message) in the `OPDSCatalogBrowserViewModel`, emitting a diagnostic log when the action is triggered. 
- Add fixture-backed unit tests and small helpers: `OPDSClientTest` exercises malformed fixtures and retry behavior, test fixtures are placed under `src/test/resources/opds/`, and `OPDSService` exposes a `buildSearchUrl` helper used for accurate report context.

### Testing
- Added unit tests in `OPDSClientTest` covering: parsing a malformed Internet Archive–style feed, handling orphan numeric/entity prefixes, retry-success on transient 5xx, non-retry behavior for 404, and explicit parser-failure behavior. 
- Attempted to run the new tests with `./gradlew :CleverFerret:testDebugUnitTest --tests com.universalmedialibrary.services.opds.OPDSClientTest` but execution aborted due to the environment Java runtime mismatch (runtime is Java 25 while the project requires JDK 17–21). 
- Test fixtures were added under `src/test/resources/opds/` and are exercised by the unit tests when run in a correctly provisioned environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c6b497a483239e5804bfb440a04f)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens OPDS feed parsing against real-world malformed XML from providers like Internet Archive by extending XML sanitization to handle orphan numeric entities and unterminated named entities (in addition to bare ampersands). It adds exponential-backoff retry logic for transient HTTP failures (5xx codes, timeouts, network errors) while explicitly surfacing fatal parser errors without retry. A **Report feed** button is added to the error UI which captures and logs diagnostic context including catalog name, requested URL, search query, and error message to help operators triage feed issues. The changes are supported by fixture-based unit tests covering malformed entity handling and retry behavior.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/src/test/resources/opds/internet_archive_malformed_entities.xml` |
| 2 | `CleverFerret/src/test/resources/opds/orphan_numeric_entity.xml` |
| 3 | `CleverFerret/src/main/java/com/universalmedialibrary/services/opds/OPDSClient.kt` |
| 4 | `CleverFerret/src/test/java/com/universalmedialibrary/services/opds/OPDSClientTest.kt` |
| 5 | `CleverFerret/src/main/java/com/universalmedialibrary/services/opds/OPDSService.kt` |
| 6 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/opds/OPDSCatalogBrowserScreen.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->