### PR TITLE
Refactor media home sticky header to CenterAlignedTopAppBar and add UI tests

### DIFF
--- a/CleverFerret/src/androidTest/java/com/universalmedialibrary/ui/media/screens/StickyContentLibraryHeaderTest.kt
+++ b/CleverFerret/src/androidTest/java/com/universalmedialibrary/ui/media/screens/StickyContentLibraryHeaderTest.kt
@@ -1,0 +1,87 @@
+package com.universalmedialibrary.ui.media.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.dp
+import com.universalmedialibrary.ui.media.theme.MediaTheme
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class StickyContentLibraryHeaderTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun stickyHeader_showsExpectedTopBarElements_withoutLegacyBranding() {
+        composeTestRule.setContent {
+            MediaTheme {
+                StickyContentLibraryHeader(
+                    onSearchClick = {},
+                    onNotificationClick = {}
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_NAV_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_SEARCH_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_NOTIFICATIONS_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Content").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Library").assertDoesNotExist()
+    }
+
+    @Test
+    fun stickyHeader_expandedWidth_increasesHamburgerInset_andPreservesSearchAlignment() {
+        fun setHeader(width: Int) {
+            composeTestRule.setContent {
+                MediaTheme {
+                    Box(
+                        modifier = Modifier
+                            .requiredWidth(width.dp)
+                            .fillMaxHeight()
+                    ) {
+                        StickyContentLibraryHeader(
+                            onSearchClick = {},
+                            onNotificationClick = {}
+                        )
+                    }
+                }
+            }
+        }
+
+        setHeader(width = 420)
+        val compactNavLeft = composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_NAV_TAG)
+            .fetchSemanticsNode().positionInRoot.x
+        val compactSearchLeft = composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_SEARCH_TAG)
+            .fetchSemanticsNode().positionInRoot.x
+        val compactSearchRight = composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_SEARCH_TAG)
+            .fetchSemanticsNode().boundsInRoot.right
+        val compactNotificationLeft = composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_NOTIFICATIONS_TAG)
+            .fetchSemanticsNode().positionInRoot.x
+
+        setHeader(width = 1000)
+        val expandedNavLeft = composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_NAV_TAG)
+            .fetchSemanticsNode().positionInRoot.x
+        val expandedSearchLeft = composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_SEARCH_TAG)
+            .fetchSemanticsNode().positionInRoot.x
+        val expandedSearchRight = composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_SEARCH_TAG)
+            .fetchSemanticsNode().boundsInRoot.right
+        val expandedNotificationLeft = composeTestRule.onNodeWithTag(MEDIA_HOME_TOP_BAR_NOTIFICATIONS_TAG)
+            .fetchSemanticsNode().positionInRoot.x
+
+        assertTrue(expandedNavLeft > compactNavLeft)
+        assertTrue(compactSearchLeft > compactNavLeft)
+        assertTrue(expandedSearchLeft > expandedNavLeft)
+        assertTrue(compactSearchRight < compactNotificationLeft)
+        assertTrue(expandedSearchRight < expandedNotificationLeft)
+    }
+}

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/screens/MediaHomeScreen.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/screens/MediaHomeScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.testTag
 import coil.compose.AsyncImage
 import com.universalmedialibrary.R
 import com.universalmedialibrary.ui.media.components.*
@@ -55,6 +56,11 @@ import com.universalmedialibrary.ui.media.theme.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
+
+internal const val MEDIA_HOME_TOP_BAR_TAG = "media_home_top_bar"
+internal const val MEDIA_HOME_TOP_BAR_NAV_TAG = "media_home_top_bar_nav_icon"
+internal const val MEDIA_HOME_TOP_BAR_SEARCH_TAG = "media_home_top_bar_search"
+internal const val MEDIA_HOME_TOP_BAR_NOTIFICATIONS_TAG = "media_home_top_bar_notifications"
 
 /**
  * Clean Media-Centric Home/Dashboard Screen
@@ -78,6 +84,7 @@ fun MediaHomeScreen(
     onPlayClick: (MediaItem) -> Unit,
     onSeeAllClick: (String) -> Unit,
     onQuickAccessCategoryClick: (String) -> Unit,
+    onNavigationClick: () -> Unit = {},
     onSearchClick: () -> Unit,
     onNotificationClick: () -> Unit,
     onAddLocalFilesClick: () -> Unit = {},
@@ -148,6 +155,7 @@ fun MediaHomeScreen(
     Scaffold(
         topBar = {
             StickyContentLibraryHeader(
+                onNavigationClick = onNavigationClick,
                 onSearchClick = onSearchClick,
                 onNotificationClick = onNotificationClick
             )
@@ -1063,122 +1071,87 @@ private fun QuickAccessCard(
     }
 }
 
-// =============================================================================
-// CONTENT LIBRARY HEADER (Matching mockup)
-// =============================================================================
-
-@Composable
-private fun ContentLibraryHeader(
-    onSearchClick: () -> Unit
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.background.copy(alpha = 0.8f),
-        tonalElevation = 0.dp
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .statusBarsPadding()
-                .padding(horizontal = MediaSpacing.LG, vertical = MediaSpacing.LG),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            // "Content Library" branding matching mockup
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(MediaSpacing.SM)
-            ) {
-                Text(
-                    text = "Content ",
-                    style = MediaTypography.TitleMedium,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    fontWeight = FontWeight.Bold
-                )
-                Text(
-                    text = "Library",
-                    style = MediaTypography.TitleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-            
-            // Search button - circular style matching mockup
-            Surface(
-                modifier = Modifier.size(40.dp),
-                shape = CircleShape,
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.05f),
-                onClick = onSearchClick
-            ) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Search,
-                        contentDescription = "Search",
-                        tint = MaterialTheme.colorScheme.onBackground,
-                        modifier = Modifier.size(MediaSizes.IconMD)
-                    )
-                }
-            }
-        }
-    }
-}
-
-// =============================================================================
-// STICKY CONTENT LIBRARY HEADER (Fixed at top)
-// =============================================================================
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun StickyContentLibraryHeader(
+internal fun StickyContentLibraryHeader(
+    onNavigationClick: () -> Unit = {},
     onSearchClick: () -> Unit,
     onNotificationClick: () -> Unit
 ) {
-    TopAppBar(
+    BoxWithConstraints {
+        val expandedWidth = maxWidth >= 840.dp
+        val horizontalPadding = if (expandedWidth) 16.dp else 4.dp
+        val searchEndPadding = if (expandedWidth) 12.dp else 4.dp
+
+        CenterAlignedTopAppBar(
+            modifier = Modifier.testTag(MEDIA_HOME_TOP_BAR_TAG),
         title = {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(0.dp)
-            ) {
-                Text(
-                    text = "Content ",
-                    style = MediaTypography.TitleMedium,
-                    color = MaterialTheme.colorScheme.onBackground,
-                    fontWeight = FontWeight.Bold
-                )
-                Text(
-                    text = "Library",
-                    style = MediaTypography.TitleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-        },
-        actions = {
-            // Notifications button
-            IconButton(onClick = onNotificationClick) {
-                Icon(
-                    imageVector = Icons.Default.Notifications,
-                    contentDescription = "Notifications",
-                    tint = MaterialTheme.colorScheme.onBackground
-                )
-            }
-            // Search button
-            IconButton(onClick = onSearchClick) {
-                Icon(
-                    imageVector = Icons.Default.Search,
-                    contentDescription = "Search",
-                    tint = MaterialTheme.colorScheme.onBackground
-                )
-            }
-        },
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = MaterialTheme.colorScheme.background,
-            titleContentColor = MaterialTheme.colorScheme.onBackground
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(end = searchEndPadding)
+                        .testTag(MEDIA_HOME_TOP_BAR_SEARCH_TAG),
+                    shape = CircleShape,
+                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.85f),
+                    onClick = onSearchClick
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(min = 40.dp)
+                            .padding(horizontal = MediaSpacing.MD, vertical = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(MediaSpacing.SM)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.size(MediaSizes.IconSM)
+                        )
+                        Text(
+                            text = stringResource(id = R.string.search_hint),
+                            style = MediaTypography.BodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            },
+            navigationIcon = {
+                IconButton(
+                    onClick = onNavigationClick,
+                    modifier = Modifier
+                        .padding(start = horizontalPadding)
+                        .testTag(MEDIA_HOME_TOP_BAR_NAV_TAG)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Menu,
+                        contentDescription = "Navigation menu",
+                        tint = MaterialTheme.colorScheme.onBackground
+                    )
+                }
+            },
+            actions = {
+                IconButton(
+                    onClick = onNotificationClick,
+                    modifier = Modifier.testTag(MEDIA_HOME_TOP_BAR_NOTIFICATIONS_TAG)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Notifications,
+                        contentDescription = "Notifications",
+                        tint = MaterialTheme.colorScheme.onBackground
+                    )
+                }
+            },
+            expandedHeight = TopAppBarDefaults.TopAppBarExpandedHeight,
+            windowInsets = WindowInsets.statusBars,
+            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+                containerColor = MaterialTheme.colorScheme.background,
+                titleContentColor = MaterialTheme.colorScheme.onBackground
+            ),
+            titleHorizontalAlignment = Alignment.CenterHorizontally
         )
-    )
+    }
 }
 
 // =============================================================================


### PR DESCRIPTION
### Motivation
- Remove legacy "Content Library" branding from the media home sticky header and modernize the top bar to match Material3 patterns. 
- Improve navigation icon placement, surface-level search affordance, and spacing so the header behaves correctly across compact and expanded widths. 
- Add automated Compose UI assertions to guard alignment and visibility of the new top-bar elements.

### Description
- Replaced the branded header and its `TopAppBar` implementation with a `CenterAlignedTopAppBar` that embeds a tappable search `Surface` in the `title` slot and places the hamburger/menu in the `navigationIcon` slot. 
- Removed the obsolete `ContentLibraryHeader` composable and added an `onNavigationClick` parameter to `MediaHomeScreen` which is forwarded to `StickyContentLibraryHeader`. 
- Introduced stable test tags (`MEDIA_HOME_TOP_BAR_TAG`, `MEDIA_HOME_TOP_BAR_NAV_TAG`, `MEDIA_HOME_TOP_BAR_SEARCH_TAG`, `MEDIA_HOME_TOP_BAR_NOTIFICATIONS_TAG`) and normalized compact/expanded paddings for hamburger alignment. 
- Added Compose UI tests at `CleverFerret/src/androidTest/.../StickyContentLibraryHeaderTest.kt` that assert visibility of nav/search/notification elements and validate compact vs expanded alignment behavior.

### Testing
- Added Compose UI tests but they were not executed in this environment because the attempted automated build `./gradlew :CleverFerret:compileDebugKotlin :CleverFerret:compileDebugAndroidTestKotlin --no-daemon` failed due to an unsupported Java runtime (detected JDK 25 while the project requires JDK 17–21).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c6b5c81c8323b1e5e6eae94977b2)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR modernizes the media home screen header by replacing the legacy "Content Library" branding with a Material3 `CenterAlignedTopAppBar`. The refactor introduces a tappable search surface in the title slot, adds a hamburger menu in the navigation slot, and implements responsive padding for both compact and expanded screen widths. The changes include new test tags (`MEDIA_HOME_TOP_BAR_TAG`, `MEDIA_HOME_TOP_BAR_NAV_TAG`, `MEDIA_HOME_TOP_BAR_SEARCH_TAG`, `MEDIA_HOME_TOP_BAR_NOTIFICATIONS_TAG`) and comprehensive Compose UI tests that verify element visibility and alignment behavior across different screen sizes.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/media/screens/MediaHomeScreen.kt` |
| 2 | `CleverFerret/src/androidTest/java/com/universalmedialibrary/ui/media/screens/StickyContentLibraryHeaderTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->