### PR TITLE
Unify primary library navigation and add phase-one route tests

### DIFF
--- a/CleverFerret/src/androidTest/java/com/universalmedialibrary/ui/media/navigation/LibraryNavigationFlowTest.kt
+++ b/CleverFerret/src/androidTest/java/com/universalmedialibrary/ui/media/navigation/LibraryNavigationFlowTest.kt
@@ -1,0 +1,47 @@
+package com.universalmedialibrary.ui.media.navigation
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.universalmedialibrary.ui.media.MediaMainActivity
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+class LibraryNavigationFlowTest {
+
+    @get:Rule
+    val hiltRule = HiltAndroidRule(this)
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MediaMainActivity>()
+
+    @Before
+    fun setup() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun libraryDestination_exposesMediaTypeChipsAndNavigatesBetweenTypes() {
+        composeTestRule.onNodeWithContentDescription("Library").assertIsDisplayed().performClick()
+        composeTestRule.onNodeWithText("Books").assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription("Library type Audiobooks")
+            .assertIsDisplayed()
+            .performClick()
+        composeTestRule.onNodeWithText("Audiobooks").assertIsDisplayed()
+
+        composeTestRule.onNodeWithContentDescription("Library type Music")
+            .assertIsDisplayed()
+            .performClick()
+        composeTestRule.onNodeWithText("Music").assertIsDisplayed()
+    }
+}

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/navigation/MediaAppNavigation.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/navigation/MediaAppNavigation.kt
@@ -44,6 +44,18 @@ import com.universalmedialibrary.ui.reader.DocumentReaderScreen
 import com.universalmedialibrary.ui.reader.EPUBReaderScreen
 import java.io.File
 
+private val libraryTypeOptions = listOf(
+    LibraryMediaTypeOption("book", "Books", MediaType.BOOK),
+    LibraryMediaTypeOption("audiobook", "Audiobooks", MediaType.AUDIOBOOK),
+    LibraryMediaTypeOption("comic", "Comics", MediaType.COMIC),
+    LibraryMediaTypeOption("music", "Music", MediaType.MUSIC),
+    LibraryMediaTypeOption("podcast", "Podcasts", MediaType.PODCAST),
+    LibraryMediaTypeOption("movie", "Movies", MediaType.MOVIE),
+    LibraryMediaTypeOption("tv_show", "TV Shows", MediaType.TV_SHOW),
+    LibraryMediaTypeOption("document", "Documents", MediaType.DOCUMENT),
+    LibraryMediaTypeOption("webfiction", "Web Fiction", MediaType.FANFICTION)
+)
+
 /**
  * Main Navigation Routes for Clean media-centric CleverFerret
  */
@@ -55,6 +67,7 @@ object MediaRoutes {
     const val SETTINGS = "settings"
     
     // Library routes
+    const val LIBRARY_ROOT = "library"
     const val LIBRARY = "library/{mediaType}"
     const val BOOKS = "library/book"
     const val AUDIOBOOKS = "library/audiobook"
@@ -170,6 +183,7 @@ private val knownStaticRoutes = setOf(
     MediaRoutes.SEARCH,
     MediaRoutes.ACTIVITY,
     MediaRoutes.SETTINGS,
+    MediaRoutes.LIBRARY_ROOT,
     MediaRoutes.BOOKS,
     MediaRoutes.AUDIOBOOKS,
     MediaRoutes.MUSIC,
@@ -451,7 +465,7 @@ fun MediaAppNavHost(
                 requestedPath = requestedPath,
                 onNavigateHome = { navController.navigate(MediaRoutes.HOME) },
                 onNavigateSearch = { navController.navigate(MediaRoutes.SEARCH) },
-                onNavigateLibrary = { navController.navigate(MediaRoutes.BOOKS) },
+                onNavigateLibrary = { navController.navigate(MediaRoutes.LIBRARY_ROOT) },
                 onBack = { navController.popBackStack() }
             )
         }
@@ -502,7 +516,15 @@ fun MediaAppNavHost(
         // =====================================================================
         // LIBRARY SCREENS
         // =====================================================================
-        
+
+        composable(MediaRoutes.LIBRARY_ROOT) {
+            LaunchedEffect(Unit) {
+                navController.navigate(MediaRoutes.BOOKS) {
+                    launchSingleTop = true
+                }
+            }
+        }
+
         composable(
             route = MediaRoutes.LIBRARY,
             arguments = listOf(navArgument("mediaType") { type = NavType.StringType })
@@ -517,6 +539,13 @@ fun MediaAppNavHost(
             ) {
                 MediaLibraryScreen(
                     state = state,
+                    mediaTypeOptions = libraryTypeOptions,
+                    currentMediaTypeRoute = mediaType,
+                    onMediaTypeSelected = { selectedType ->
+                        navController.navigate(MediaRoutes.libraryRoute(selectedType)) {
+                            launchSingleTop = true
+                        }
+                    },
                     onItemClick = { item ->
                         navController.navigate(MediaRoutes.mediaDetailRoute(mediaType, item.id))
                     },
@@ -1841,6 +1870,13 @@ fun MediaAppNavHost(
             ) {
                 MediaLibraryScreen(
                     state = state,
+                    mediaTypeOptions = libraryTypeOptions,
+                    currentMediaTypeRoute = mediaType,
+                    onMediaTypeSelected = { selectedType ->
+                        navController.navigate(MediaRoutes.libraryRoute(selectedType)) {
+                            launchSingleTop = true
+                        }
+                    },
                     onItemClick = { item ->
                         navController.navigate(MediaRoutes.mediaDetailRoute(mediaType, item.id))
                     },

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/navigation/MediaNavigation.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/navigation/MediaNavigation.kt
@@ -116,6 +116,15 @@ object MediaNavDestinations {
         route = MediaRoutes.DISCOVER,
         section = NavSection.DISCOVER
     )
+
+    val library = MediaNavDestination(
+        id = "library",
+        label = "Library",
+        icon = Icons.Outlined.VideoLibrary,
+        selectedIcon = Icons.Filled.VideoLibrary,
+        route = MediaRoutes.LIBRARY_ROOT,
+        section = NavSection.LIBRARY
+    )
     
     // Library Section
     val books = MediaNavDestination(
@@ -349,6 +358,7 @@ object MediaNavDestinations {
     val allDestinations = listOf(
         home,
         search,
+        library,
         books, audiobooks, comics, movies, tvShows, music, podcasts, radio, documents,
         discover, webFiction, opds, freeAudiobooks, hivefy, ambient, visualizer, landseek,
         downloads, storage, sync, importExport,
@@ -361,16 +371,9 @@ object MediaNavDestinations {
     // On phones the bar is horizontally scrollable, so we can expose all major segments.
     val primaryDestinations = listOf(
         home,
+        library,
         discover,
         search,
-        books,
-        music,
-        podcasts,
-        radio,
-        audiobooks,
-        comics,
-        movies,
-        tvShows,
         webFiction,
         opds,
         ambient,
@@ -1093,15 +1096,15 @@ private fun applyBottomBarPreferencesToMediaDestinations(
     fun mapLegacyPreferenceIdToMediaRoute(id: String): String? = when (id) {
         "home" -> MediaRoutes.HOME
         "enhanced_search" -> MediaRoutes.SEARCH
-        "library_details/1" -> MediaRoutes.BOOKS
-        "library_details/2" -> MediaRoutes.AUDIOBOOKS
-        "library_details/3" -> MediaRoutes.COMICS
-        "library_details/4" -> MediaRoutes.MOVIES
-        "library_details/5" -> MediaRoutes.TV_SHOWS
-        "library_details/7" -> MediaRoutes.DOCUMENTS
-        "music" -> MediaRoutes.MUSIC
-        "podcasts" -> MediaRoutes.PODCASTS
-        "radio" -> MediaRoutes.RADIO
+        "library_details/1" -> MediaRoutes.LIBRARY_ROOT
+        "library_details/2" -> MediaRoutes.LIBRARY_ROOT
+        "library_details/3" -> MediaRoutes.LIBRARY_ROOT
+        "library_details/4" -> MediaRoutes.LIBRARY_ROOT
+        "library_details/5" -> MediaRoutes.LIBRARY_ROOT
+        "library_details/7" -> MediaRoutes.LIBRARY_ROOT
+        "music" -> MediaRoutes.LIBRARY_ROOT
+        "podcasts" -> MediaRoutes.LIBRARY_ROOT
+        "radio" -> MediaRoutes.LIBRARY_ROOT
         "visualizer" -> MediaRoutes.VISUALIZER
         "ambient" -> MediaRoutes.AMBIENT_SOUNDS
         "webfiction_manager" -> MediaRoutes.WEB_FICTION

--- a/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/screens/MediaLibraryScreen.kt
+++ b/CleverFerret/src/main/java/com/universalmedialibrary/ui/media/screens/MediaLibraryScreen.kt
@@ -19,12 +19,20 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.universalmedialibrary.ui.media.components.*
 import com.universalmedialibrary.ui.media.theme.*
+
+data class LibraryMediaTypeOption(
+    val routeType: String,
+    val label: String,
+    val mediaType: MediaType
+)
 
 /**
  * Clean Media-Centric Library Screen
@@ -49,6 +57,9 @@ import com.universalmedialibrary.ui.media.theme.*
 @Composable
 fun MediaLibraryScreen(
     state: LibraryScreenState,
+    mediaTypeOptions: List<LibraryMediaTypeOption>,
+    currentMediaTypeRoute: String,
+    onMediaTypeSelected: (String) -> Unit,
     onItemClick: (MediaItem) -> Unit,
     onBackClick: () -> Unit,
     onSearchClick: () -> Unit,
@@ -80,6 +91,12 @@ fun MediaLibraryScreen(
                 .fillMaxSize()
                 .padding(paddingValues)
         ) {
+            MediaTypeChipsRow(
+                mediaTypeOptions = mediaTypeOptions,
+                currentMediaTypeRoute = currentMediaTypeRoute,
+                onMediaTypeSelected = onMediaTypeSelected
+            )
+
             // Quick filters row
             QuickFiltersRow(
                 currentFilter = state.currentFilter,
@@ -162,6 +179,40 @@ fun MediaLibraryScreen(
                     showFilterSheet = false
                 },
                 onDismiss = { showFilterSheet = false }
+            )
+        }
+    }
+}
+
+@Composable
+private fun MediaTypeChipsRow(
+    mediaTypeOptions: List<LibraryMediaTypeOption>,
+    currentMediaTypeRoute: String,
+    onMediaTypeSelected: (String) -> Unit
+) {
+    LazyRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = MediaSpacing.SM),
+        contentPadding = PaddingValues(horizontal = MediaSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(MediaSpacing.SM)
+    ) {
+        items(mediaTypeOptions) { option ->
+            val selected = currentMediaTypeRoute == option.routeType
+            FilterChip(
+                selected = selected,
+                onClick = { onMediaTypeSelected(option.routeType) },
+                label = { Text(option.label) },
+                leadingIcon = {
+                    Icon(
+                        imageVector = option.mediaType.icon,
+                        contentDescription = option.label,
+                        modifier = Modifier.size(16.dp)
+                    )
+                },
+                modifier = Modifier.semantics {
+                    contentDescription = "Library type ${option.label}"
+                }
             )
         }
     }

--- a/docs/navigation/NAVIGATION_SURFACE_AUDIT_PHASE1.md
+++ b/docs/navigation/NAVIGATION_SURFACE_AUDIT_PHASE1.md
@@ -1,0 +1,41 @@
+# Navigation Surface Audit (Phase 1)
+
+## Current Navigation Surfaces
+
+### Primary surfaces in production flow
+- **Home**: `home` route, start destination in `MediaAppNavHost`.
+- **My Library / Library family**:
+  - Canonical typed route: `library/{mediaType}`.
+  - Per-type aliases: `library/book`, `library/audiobook`, `library/music`, `library/podcast`, etc.
+  - Legacy aliases: `library_details/{typeId}` mapping to typed routes.
+- **Per-type destinations outside typed library**:
+  - Dedicated music screen: `music`.
+  - Dedicated podcast screen: `podcasts`.
+  - Web fiction manager and radio routes with separate entry points.
+
+### Entry points that exposed overlap
+- Mobile bottom bar (`MediaNavDestinations.primaryDestinations`) previously listed multiple library-type tabs directly (`Books`, `Audiobooks`, `Comics`, `Movies`, `TV Shows`, `Music`, `Podcasts`, `Radio`).
+- Legacy bottom bar preference IDs map to those same per-type routes.
+- Navigation graph supports both typed library routes and legacy numeric type routes.
+
+## Confusion-causing overlap
+
+1. **Competing “Library” affordances**
+   - Users could enter “Library” concepts from many peer-level tabs (Books, Music, Podcasts, etc.) instead of one obvious Library home.
+2. **Duplicate taxonomy**
+   - Media-type categories appeared as top-level nav items and also as in-screen content concepts.
+3. **Legacy + modern route coexistence**
+   - `library_details/{typeId}` and `library/{mediaType}` both active, which complicates mental model and test coverage.
+
+## Phase-one refactor scope (implemented)
+
+- Added one **primary Library destination** (`library`) for bottom-bar first navigation.
+- Kept existing typed routes (`library/{mediaType}`) as data/viewmodel contract entry points.
+- Added media-type chips in library UI composition so users switch between books/audiobooks/music/etc. from within library context.
+- Preserved legacy route compatibility by mapping old bottom-bar preference IDs to the new primary `library` destination.
+
+## Explicit non-goals (phase one)
+
+- No repository schema/model redesign.
+- No media repository contract migration.
+- No removal of existing specialized screens (music/podcast/radio) in this phase.


### PR DESCRIPTION
### Motivation
- Users were confused by duplicate library entry points (per-type top-level tabs like `Books`/`Music` plus typed `library/{mediaType}` routes), so a single primary Library surface was needed to centralize media-type switching.
- Phase-one goal: refactor navigation/UI composition only (no repository or model changes) so the Library becomes the single primary destination while preserving existing data-layer route contracts.
- Add lightweight instrumentation to assert the new route flow and make the UI discoverable for future migration phases.

### Description
- Introduced a primary library route `MediaRoutes.LIBRARY_ROOT` (`"library"`) and added a `library` destination to the mobile bottom bar composition so Library is a single top-level entry point instead of multiple per-type tabs.
- Preserved compatibility with existing typed routes (`library/{mediaType}`) and legacy IDs by mapping legacy bottom-bar preference IDs (e.g. `library_details/*`, `music`, `podcasts`, `radio`) to `MediaRoutes.LIBRARY_ROOT` in `applyBottomBarPreferencesToMediaDestinations`.
- Added in-library media-type UI: `LibraryMediaTypeOption` model, `MediaTypeChipsRow` + `MediaTypeChipsRow` integration into `MediaLibraryScreen`, and `libraryTypeOptions` wiring in `MediaAppNavigation` so users switch types inside the Library without changing repository contracts.
- Added docs audit `docs/navigation/NAVIGATION_SURFACE_AUDIT_PHASE1.md` describing current surfaces, overlap, scope and non-goals, and created an Android instrumentation test `LibraryNavigationFlowTest` validating the new Library → media-type chip navigation flow.

### Testing
- Added an Android instrumentation test `CleverFerret/src/androidTest/.../LibraryNavigationFlowTest.kt` that clicks the new `Library` destination and verifies media-type chips navigate between `Books`, `Audiobooks`, and `Music` (test committed but not executed in this environment).
- Attempted to run unit tests (`:CleverFerret:testDebugUnitTest --tests com.universalmedialibrary.ui.media.navigation.MediaNavDestinationsContractTest`) but execution failed due to environment JDK mismatch: runtime is Java 25 while project requires JDK 17–21, so automated tests were not run here.
- No runtime repository/model changes were made, so integration with existing viewmodels/data flows remains unchanged and test coverage for those flows should continue to work once the CI or local dev environment uses a supported JDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4c6b719488323bcbe7586ab07d1d8)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR consolidates the library navigation experience by introducing a unified `Library` entry point in the mobile bottom bar, replacing multiple per-media-type tabs (Books, Music, Podcasts, etc.) that previously caused user confusion. The refactor adds in-library media-type chips for switching between content types while preserving backward compatibility with existing typed routes and legacy preference IDs. Additionally, it includes a new Android instrumentation test to validate the navigation flow and comprehensive documentation explaining the scope and non-goals of this phase-one UI refactor.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/navigation/NAVIGATION_SURFACE_AUDIT_PHASE1.md` |
| 2 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/media/navigation/MediaNavigation.kt` |
| 3 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/media/navigation/MediaAppNavigation.kt` |
| 4 | `CleverFerret/src/main/java/com/universalmedialibrary/ui/media/screens/MediaLibraryScreen.kt` |
| 5 | `CleverFerret/src/androidTest/java/com/universalmedialibrary/ui/media/navigation/LibraryNavigationFlowTest.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->