### PR TITLE
Plex auth-first: device/PIN flow, token lifecycle, sync checkpointing, and tests

### DIFF
--- a/CleverFerretV2/core/auth/build.gradle.kts
+++ b/CleverFerretV2/core/auth/build.gradle.kts
@@ -1,3 +1,5 @@
 dependencies {
     api(project(":core:common"))
+
+    testImplementation(kotlin("test"))
 }

--- a/CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/AuthContracts.kt
+++ b/CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/AuthContracts.kt
@@ -1,0 +1,22 @@
+package com.cleverferret.v2.core.auth
+
+import com.cleverferret.v2.core.common.result.IntegrationResult
+
+interface TokenStore {
+    fun read(): AuthTokens?
+    fun write(tokens: AuthTokens)
+    fun clear()
+}
+
+interface SensitiveCache {
+    fun clearSensitiveData()
+}
+
+interface DevicePinAuthClient {
+    fun startDevicePinFlow(): IntegrationResult<DevicePinChallenge>
+    fun pollForAccessToken(deviceCode: String): IntegrationResult<AuthTokens>
+}
+
+interface TokenRefreshClient {
+    fun refresh(refreshToken: String): IntegrationResult<AuthTokens>
+}

--- a/CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/AuthModels.kt
+++ b/CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/AuthModels.kt
@@ -1,0 +1,24 @@
+package com.cleverferret.v2.core.auth
+
+data class AuthTokens(
+    val accessToken: String,
+    val refreshToken: String?,
+    val expiresAtEpochMillis: Long,
+) {
+    fun isExpired(nowEpochMillis: Long): Boolean = nowEpochMillis >= expiresAtEpochMillis
+}
+
+data class DevicePinChallenge(
+    val deviceCode: String,
+    val userCode: String,
+    val verificationUri: String,
+    val expiresAtEpochMillis: Long,
+    val pollIntervalSeconds: Int,
+)
+
+data class AuthSessionState(
+    val connectedAccountId: String,
+    val connectedAtEpochMillis: Long,
+    val lastHealthCheckEpochMillis: Long,
+    val healthy: Boolean,
+)

--- a/CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/AuthSessionManager.kt
+++ b/CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/AuthSessionManager.kt
@@ -1,0 +1,57 @@
+package com.cleverferret.v2.core.auth
+
+import com.cleverferret.v2.core.common.error.AppError
+import com.cleverferret.v2.core.common.error.UserFacingState
+import com.cleverferret.v2.core.common.result.IntegrationResult
+
+class AuthSessionManager(
+    private val tokenStore: TokenStore,
+    private val refreshClient: TokenRefreshClient,
+    private val nowEpochMillis: () -> Long,
+) {
+    fun beginDevicePinFlow(client: DevicePinAuthClient): IntegrationResult<DevicePinChallenge> =
+        client.startDevicePinFlow()
+
+    fun completeDevicePinFlow(client: DevicePinAuthClient, deviceCode: String): IntegrationResult<AuthTokens> {
+        val result = client.pollForAccessToken(deviceCode)
+        if (result is IntegrationResult.Success<AuthTokens>) {
+            tokenStore.write(result.value)
+        }
+        return result
+    }
+
+    fun getValidAccessToken(): IntegrationResult<String> {
+        val tokens = tokenStore.read()
+            ?: return IntegrationResult.failure(
+                AppError.AuthenticationFailure("No active session", "plex"),
+                UserFacingState.AUTH_REQUIRED,
+            )
+
+        if (!tokens.isExpired(nowEpochMillis())) {
+            return IntegrationResult.success(tokens.accessToken)
+        }
+
+        val refreshToken = tokens.refreshToken
+            ?: return IntegrationResult.failure(
+                AppError.AuthenticationFailure("Session expired and refresh token is missing", "plex"),
+                UserFacingState.AUTH_REQUIRED,
+            )
+
+        return when (val refreshResult = refreshClient.refresh(refreshToken)) {
+            is IntegrationResult.Success<AuthTokens> -> {
+                tokenStore.write(refreshResult.value)
+                IntegrationResult.success(refreshResult.value.accessToken)
+            }
+            is IntegrationResult.Failure -> {
+                tokenStore.clear()
+                refreshResult
+            }
+        }
+    }
+
+    fun signOut(onLocalRevocation: () -> Unit, sensitiveCache: SensitiveCache) {
+        tokenStore.clear()
+        onLocalRevocation()
+        sensitiveCache.clearSensitiveData()
+    }
+}

--- a/CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/InMemoryTokenStore.kt
+++ b/CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/InMemoryTokenStore.kt
@@ -1,0 +1,15 @@
+package com.cleverferret.v2.core.auth
+
+class InMemoryTokenStore : TokenStore {
+    private var cached: AuthTokens? = null
+
+    override fun read(): AuthTokens? = cached
+
+    override fun write(tokens: AuthTokens) {
+        cached = tokens
+    }
+
+    override fun clear() {
+        cached = null
+    }
+}

--- a/CleverFerretV2/core/auth/src/test/java/com/cleverferret/v2/core/auth/AuthSessionManagerTest.kt
+++ b/CleverFerretV2/core/auth/src/test/java/com/cleverferret/v2/core/auth/AuthSessionManagerTest.kt
@@ -1,0 +1,86 @@
+package com.cleverferret.v2.core.auth
+
+import com.cleverferret.v2.core.common.error.AppError
+import com.cleverferret.v2.core.common.result.IntegrationResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AuthSessionManagerTest {
+    @Test
+    fun `auth success stores token and returns access token`() {
+        val store = InMemoryTokenStore()
+        val refreshClient = object : TokenRefreshClient {
+            override fun refresh(refreshToken: String) = IntegrationResult.success(
+                AuthTokens("refreshed", "refresh", expiresAtEpochMillis = 9_999),
+            )
+        }
+        val manager = AuthSessionManager(store, refreshClient) { 1_000 }
+        val deviceClient = object : DevicePinAuthClient {
+            override fun startDevicePinFlow() = IntegrationResult.success(DevicePinChallenge("d","u","https://verify",3_000,5))
+            override fun pollForAccessToken(deviceCode: String) = IntegrationResult.success(AuthTokens("access", "refresh", 2_000))
+        }
+
+        manager.completeDevicePinFlow(deviceClient, "d")
+        val token = manager.getValidAccessToken()
+
+        assertEquals("access", (token as IntegrationResult.Success).value)
+    }
+
+    @Test
+    fun `expired token refreshes`() {
+        val store = InMemoryTokenStore().apply {
+            write(AuthTokens("expired", "refresh-token", expiresAtEpochMillis = 10))
+        }
+        val manager = AuthSessionManager(store, object : TokenRefreshClient {
+            override fun refresh(refreshToken: String) = IntegrationResult.success(
+                AuthTokens("fresh", "refresh-token-2", expiresAtEpochMillis = 10_000),
+            )
+        }) { 100 }
+
+        val token = manager.getValidAccessToken()
+
+        assertEquals("fresh", (token as IntegrationResult.Success).value)
+        assertEquals("fresh", store.read()?.accessToken)
+    }
+
+    @Test
+    fun `refresh failure clears credentials`() {
+        val store = InMemoryTokenStore().apply {
+            write(AuthTokens("expired", "bad-refresh", expiresAtEpochMillis = 10))
+        }
+        val manager = AuthSessionManager(store, object : TokenRefreshClient {
+            override fun refresh(refreshToken: String) = IntegrationResult.failure(
+                AppError.AuthenticationFailure("refresh failed", "plex"),
+                com.cleverferret.v2.core.common.error.UserFacingState.AUTH_REQUIRED,
+            )
+        }) { 100 }
+
+        val result = manager.getValidAccessToken()
+
+        assertIs<IntegrationResult.Failure>(result)
+        assertNull(store.read())
+    }
+
+    @Test
+    fun `sign out clears token and cache`() {
+        val store = InMemoryTokenStore().apply { write(AuthTokens("access", "refresh", 1000)) }
+        var localRevoked = false
+        var sensitiveCleared = false
+        val manager = AuthSessionManager(store, object : TokenRefreshClient {
+            override fun refresh(refreshToken: String): IntegrationResult<AuthTokens> = error("unused")
+        }) { 0 }
+
+        manager.signOut(onLocalRevocation = { localRevoked = true }, sensitiveCache = object : SensitiveCache {
+            override fun clearSensitiveData() {
+                sensitiveCleared = true
+            }
+        })
+
+        assertNull(store.read())
+        assertTrue(localRevoked)
+        assertTrue(sensitiveCleared)
+    }
+}

--- a/CleverFerretV2/core/network/build.gradle.kts
+++ b/CleverFerretV2/core/network/build.gradle.kts
@@ -1,3 +1,6 @@
 dependencies {
     api(project(":core:common"))
+    implementation(project(":core:auth"))
+
+    testImplementation(kotlin("test"))
 }

--- a/CleverFerretV2/core/network/src/main/java/com/cleverferret/v2/core/network/plex/AuthenticatedPlexRequestExecutor.kt
+++ b/CleverFerretV2/core/network/src/main/java/com/cleverferret/v2/core/network/plex/AuthenticatedPlexRequestExecutor.kt
@@ -1,0 +1,53 @@
+package com.cleverferret.v2.core.network.plex
+
+import com.cleverferret.v2.core.auth.AuthSessionManager
+import com.cleverferret.v2.core.common.error.AppError
+import com.cleverferret.v2.core.common.error.UserFacingState
+import com.cleverferret.v2.core.common.result.IntegrationResult
+
+interface SafeLogger {
+    fun info(message: String)
+    fun warn(message: String)
+}
+
+object TokenRedactor {
+    private val tokenPattern = Regex("(?i)(token=|bearer\\s+)([a-z0-9._-]+)")
+
+    fun sanitize(message: String): String = tokenPattern.replace(message) { match ->
+        "${match.groupValues[1]}[REDACTED]"
+    }
+}
+
+class AuthenticatedPlexRequestExecutor(
+    private val sessionManager: AuthSessionManager,
+    private val logger: SafeLogger,
+) {
+    fun <T> execute(operationName: String, operation: (String) -> IntegrationResult<T>): IntegrationResult<T> {
+        val tokenResult = sessionManager.getValidAccessToken()
+        if (tokenResult is IntegrationResult.Failure) return tokenResult
+
+        val token = (tokenResult as IntegrationResult.Success<String>).value
+        val firstAttempt = operation(token)
+        if (firstAttempt !is IntegrationResult.Failure || firstAttempt.error !is AppError.AuthenticationFailure) {
+            return firstAttempt
+        }
+
+        logger.warn(TokenRedactor.sanitize("$operationName failed: token expired, attempting refresh"))
+        val refreshed = sessionManager.getValidAccessToken()
+        if (refreshed is IntegrationResult.Failure) {
+            logger.warn(TokenRedactor.sanitize("$operationName refresh failed: ${refreshed.error.message}"))
+            return refreshed
+        }
+
+        logger.info(TokenRedactor.sanitize("$operationName retrying after refresh"))
+        return operation((refreshed as IntegrationResult.Success<String>).value)
+    }
+
+    companion object {
+        fun authenticationFailure(message: String = "Token expired"): IntegrationResult.Failure =
+            IntegrationResult.Failure(
+                AppError.AuthenticationFailure(message, "plex"),
+                UserFacingState.AUTH_REQUIRED,
+            )
+    }
+}

--- a/CleverFerretV2/core/network/src/main/java/com/cleverferret/v2/core/network/plex/PlexIntegrationBoundary.kt
+++ b/CleverFerretV2/core/network/src/main/java/com/cleverferret/v2/core/network/plex/PlexIntegrationBoundary.kt
@@ -1,0 +1,28 @@
+package com.cleverferret.v2.core.network.plex
+
+import com.cleverferret.v2.core.auth.AuthTokens
+import com.cleverferret.v2.core.auth.DevicePinChallenge
+import com.cleverferret.v2.core.common.result.IntegrationResult
+
+interface PlexAuthBoundary {
+    fun startDevicePinFlow(): IntegrationResult<DevicePinChallenge>
+    fun pollDevicePin(deviceCode: String): IntegrationResult<AuthTokens>
+    fun refreshToken(refreshToken: String): IntegrationResult<AuthTokens>
+}
+
+interface PlexMetadataBoundary {
+    fun fetchMetadataPage(accessToken: String, pageCursor: String?): IntegrationResult<PlexMetadataPage>
+}
+
+data class PlexMetadataRecord(
+    val ratingKey: String,
+    val title: String,
+    val mediaType: String,
+    val updatedAtEpochMillis: Long,
+)
+
+data class PlexMetadataPage(
+    val records: List<PlexMetadataRecord>,
+    val nextCursor: String?,
+    val syncCheckpoint: String,
+)

--- a/CleverFerretV2/core/network/src/test/java/com/cleverferret/v2/core/network/plex/AuthenticatedPlexRequestExecutorTest.kt
+++ b/CleverFerretV2/core/network/src/test/java/com/cleverferret/v2/core/network/plex/AuthenticatedPlexRequestExecutorTest.kt
@@ -1,0 +1,55 @@
+package com.cleverferret.v2.core.network.plex
+
+import com.cleverferret.v2.core.auth.AuthSessionManager
+import com.cleverferret.v2.core.auth.AuthTokens
+import com.cleverferret.v2.core.auth.InMemoryTokenStore
+import com.cleverferret.v2.core.auth.TokenRefreshClient
+import com.cleverferret.v2.core.common.result.IntegrationResult
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class AuthenticatedPlexRequestExecutorTest {
+    @Test
+    fun `retries once when token expires mid-request`() {
+        val store = InMemoryTokenStore().apply {
+            write(AuthTokens("token-a", "refresh", 9_999))
+        }
+        val sessionManager = AuthSessionManager(store, object : TokenRefreshClient {
+            override fun refresh(refreshToken: String): IntegrationResult<AuthTokens> {
+                return IntegrationResult.success(AuthTokens("token-b", "refresh-2", 9_999))
+            }
+        }) { 100 }
+
+        val logs = mutableListOf<String>()
+        val executor = AuthenticatedPlexRequestExecutor(sessionManager, object : SafeLogger {
+            override fun info(message: String) { logs += message }
+            override fun warn(message: String) { logs += message }
+        })
+
+        var calls = 0
+        val result = executor.execute("plex.sync") { token ->
+            calls++
+            if (calls == 1) {
+                AuthenticatedPlexRequestExecutor.authenticationFailure()
+            } else {
+                IntegrationResult.success("ok:$token")
+            }
+        }
+
+        assertEquals(2, calls)
+        assertEquals("ok:token-b", (result as IntegrationResult.Success).value)
+        assertTrue(logs.any { it.contains("retrying after refresh") })
+    }
+
+    @Test
+    fun `token redactor strips leaked token values from logs`() {
+        val message = "request failed token=abc123 bearer qwerty"
+        val sanitized = TokenRedactor.sanitize(message)
+
+        assertTrue("abc123" !in sanitized)
+        assertTrue("qwerty" !in sanitized)
+        assertTrue("[REDACTED]" in sanitized)
+    }
+}

--- a/CleverFerretV2/core/ui/src/main/java/com/cleverferret/v2/core/ui/components/ActionCard.kt
+++ b/CleverFerretV2/core/ui/src/main/java/com/cleverferret/v2/core/ui/components/ActionCard.kt
@@ -1,0 +1,15 @@
+package com.cleverferret.v2.core.ui.components
+
+enum class SemanticStateColor {
+    SUCCESS,
+    WARNING,
+    ERROR,
+    NEUTRAL,
+}
+
+data class ActionCard(
+    val title: String,
+    val subtitle: String,
+    val actionLabel: String,
+    val status: SemanticStateColor,
+)

--- a/CleverFerretV2/core/ui/src/main/java/com/cleverferret/v2/core/ui/components/ComponentCatalogV1.kt
+++ b/CleverFerretV2/core/ui/src/main/java/com/cleverferret/v2/core/ui/components/ComponentCatalogV1.kt
@@ -1,35 +1,39 @@
 package com.cleverferret.v2.core.ui.components
 
-import java.util.List
-
 enum class Category {
     CARDS,
     PLAYERS,
     READER_CONTROLS,
     CHIPS,
     DIALOGS,
-    },
-    public record ComponentSpec(String name, Category category) {},
-    public static final List<ComponentSpec> REQUIRED_COMPONENTS = List.of(,
-    new ComponentSpec("MediaCard", Category.CARDS),
-    new ComponentSpec("CollectionCard", Category.CARDS),
-    new ComponentSpec("StatCard", Category.CARDS),
-    new ComponentSpec("ActionCard", Category.CARDS),
-    new ComponentSpec("MiniPlayerBar", Category.PLAYERS),
-    new ComponentSpec("NowPlayingPanel", Category.PLAYERS),
-    new ComponentSpec("QueueSheet", Category.PLAYERS),
-    new ComponentSpec("TransportControls", Category.PLAYERS),
-    new ComponentSpec("ReaderTopBar", Category.READER_CONTROLS),
-    new ComponentSpec("ReaderBottomBar", Category.READER_CONTROLS),
-    new ComponentSpec("ReaderProgressScrubber", Category.READER_CONTROLS),
-    new ComponentSpec("ReaderDisplaySettingsSheet", Category.READER_CONTROLS),
-    new ComponentSpec("FilterChip", Category.CHIPS),
-    new ComponentSpec("SelectableChip", Category.CHIPS),
-    new ComponentSpec("TagChip", Category.CHIPS),
-    new ComponentSpec("StatusChip", Category.CHIPS),
-    new ComponentSpec("ConfirmationDialog", Category.DIALOGS),
-    new ComponentSpec("FormDialog", Category.DIALOGS),
-    new ComponentSpec("ErrorDialog", Category.DIALOGS),
-    new ComponentSpec("BottomSheetDialog", Category.DIALOGS),
-    );
+}
+
+data class ComponentSpec(
+    val name: String,
+    val category: Category,
+)
+
+object ComponentCatalogV1 {
+    val requiredComponents: List<ComponentSpec> = listOf(
+        ComponentSpec("MediaCard", Category.CARDS),
+        ComponentSpec("CollectionCard", Category.CARDS),
+        ComponentSpec("StatCard", Category.CARDS),
+        ComponentSpec("ActionCard", Category.CARDS),
+        ComponentSpec("MiniPlayerBar", Category.PLAYERS),
+        ComponentSpec("NowPlayingPanel", Category.PLAYERS),
+        ComponentSpec("QueueSheet", Category.PLAYERS),
+        ComponentSpec("TransportControls", Category.PLAYERS),
+        ComponentSpec("ReaderTopBar", Category.READER_CONTROLS),
+        ComponentSpec("ReaderBottomBar", Category.READER_CONTROLS),
+        ComponentSpec("ReaderProgressScrubber", Category.READER_CONTROLS),
+        ComponentSpec("ReaderDisplaySettingsSheet", Category.READER_CONTROLS),
+        ComponentSpec("FilterChip", Category.CHIPS),
+        ComponentSpec("SelectableChip", Category.CHIPS),
+        ComponentSpec("TagChip", Category.CHIPS),
+        ComponentSpec("StatusChip", Category.CHIPS),
+        ComponentSpec("ConfirmationDialog", Category.DIALOGS),
+        ComponentSpec("FormDialog", Category.DIALOGS),
+        ComponentSpec("ErrorDialog", Category.DIALOGS),
+        ComponentSpec("BottomSheetDialog", Category.DIALOGS),
+    )
 }

--- a/CleverFerretV2/feature/plex/build.gradle.kts
+++ b/CleverFerretV2/feature/plex/build.gradle.kts
@@ -2,4 +2,8 @@ dependencies {
     api(project(":core:common"))
     api(project(":core:data"))
     implementation(project(":core:network"))
+    implementation(project(":core:auth"))
+    implementation(project(":core:ui"))
+
+    testImplementation(kotlin("test"))
 }

--- a/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/api/PlexFeatureApi.kt
+++ b/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/api/PlexFeatureApi.kt
@@ -1,9 +1,17 @@
 package com.cleverferret.v2.feature.plex.api
 
+import com.cleverferret.v2.core.auth.DevicePinChallenge
 import com.cleverferret.v2.core.common.result.IntegrationResult
+import com.cleverferret.v2.feature.plex.services.plex.PlexConnectionCardState
 import com.cleverferret.v2.feature.plex.services.plex.PlexSyncResultV1
 
 interface PlexFeatureApi {
     fun featureKey(): String
-    fun syncLibrary(accessToken: String): IntegrationResult<PlexSyncResultV1>
+
+    fun startDevicePinLink(): IntegrationResult<DevicePinChallenge>
+    fun pollDevicePinLink(deviceCode: String): IntegrationResult<Unit>
+    fun signOut(): IntegrationResult<Unit>
+
+    fun accountConnectionCardState(): PlexConnectionCardState
+    fun syncLibrary(accessToken: String? = null): IntegrationResult<PlexSyncResultV1>
 }

--- a/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/DefaultPlexFeatureApi.kt
+++ b/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/DefaultPlexFeatureApi.kt
@@ -1,0 +1,103 @@
+package com.cleverferret.v2.feature.plex.services.plex
+
+import com.cleverferret.v2.core.auth.AuthSessionManager
+import com.cleverferret.v2.core.auth.DevicePinAuthClient
+import com.cleverferret.v2.core.auth.SensitiveCache
+import com.cleverferret.v2.core.common.error.AppError
+import com.cleverferret.v2.core.common.error.UserFacingState
+import com.cleverferret.v2.core.common.result.IntegrationResult
+import com.cleverferret.v2.core.network.plex.AuthenticatedPlexRequestExecutor
+import com.cleverferret.v2.core.ui.components.ActionCard
+import com.cleverferret.v2.core.ui.components.SemanticStateColor
+import com.cleverferret.v2.feature.plex.api.PlexFeatureApi
+
+class DefaultPlexFeatureApi(
+    private val authSessionManager: AuthSessionManager,
+    private val devicePinAuthClient: DevicePinAuthClient,
+    private val requestExecutor: AuthenticatedPlexRequestExecutor,
+    private val metadataSyncService: PlexMetadataSyncService,
+    private val sensitiveCache: SensitiveCache,
+    private val nowEpochMillis: () -> Long,
+) : PlexFeatureApi {
+
+    private var connectedAccountId: String? = null
+    private var lastHealthCheckEpochMillis: Long? = null
+
+    override fun featureKey(): String = "plex"
+
+    override fun startDevicePinLink() = authSessionManager.beginDevicePinFlow(devicePinAuthClient)
+
+    override fun pollDevicePinLink(deviceCode: String): IntegrationResult<Unit> {
+        val result = authSessionManager.completeDevicePinFlow(devicePinAuthClient, deviceCode)
+        return when (result) {
+            is IntegrationResult.Success -> {
+                connectedAccountId = "plex-account"
+                IntegrationResult.success(Unit)
+            }
+            is IntegrationResult.Failure -> result
+        }
+    }
+
+    override fun signOut(): IntegrationResult<Unit> {
+        authSessionManager.signOut(onLocalRevocation = {
+            connectedAccountId = null
+            lastHealthCheckEpochMillis = null
+            metadataSyncService.clearCheckpoint()
+        }, sensitiveCache = sensitiveCache)
+        return IntegrationResult.success(Unit)
+    }
+
+    override fun accountConnectionCardState(): PlexConnectionCardState {
+        val connected = connectedAccountId != null
+        val accountCard = if (connected) {
+            ActionCard(
+                title = "Plex Account",
+                subtitle = "Connected as $connectedAccountId",
+                actionLabel = "Disconnect",
+                status = SemanticStateColor.SUCCESS,
+            )
+        } else {
+            ActionCard(
+                title = "Plex Account",
+                subtitle = "Not connected",
+                actionLabel = "Connect",
+                status = SemanticStateColor.WARNING,
+            )
+        }
+
+        val healthIsRecent = lastHealthCheckEpochMillis?.let { nowEpochMillis() - it < 5 * 60 * 1000 } ?: false
+        val serverCard = when {
+            !connected -> ActionCard("Connection Health", "Sign in to verify server health", "Verify", SemanticStateColor.NEUTRAL)
+            healthIsRecent -> ActionCard("Connection Health", "Healthy", "Re-check", SemanticStateColor.SUCCESS)
+            else -> ActionCard("Connection Health", "Needs verification", "Check now", SemanticStateColor.WARNING)
+        }
+
+        return PlexConnectionCardState(accountCard = accountCard, serverCard = serverCard)
+    }
+
+    override fun syncLibrary(accessToken: String?): IntegrationResult<PlexSyncResultV1> {
+        val syncResult = requestExecutor.execute("plex.sync.metadata") { token ->
+            metadataSyncService.importMetadata(accessToken ?: token)
+        }
+
+        return when (syncResult) {
+            is IntegrationResult.Success -> {
+                lastHealthCheckEpochMillis = nowEpochMillis()
+                IntegrationResult.success(
+                    PlexSyncResultV1(
+                        accountId = connectedAccountId ?: "plex-account",
+                        syncedItems = syncResult.value.importedItems,
+                        syncedAtEpochMillis = nowEpochMillis(),
+                        checkpoint = syncResult.value.checkpoint,
+                    ),
+                )
+            }
+            is IntegrationResult.Failure -> {
+                IntegrationResult.failure(
+                    AppError.ExternalServiceFailure(syncResult.error.message, "plex", "SYNC_FAILURE"),
+                    UserFacingState.TEMPORARILY_DEGRADED,
+                )
+            }
+        }
+    }
+}

--- a/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/PlexConnectionCardState.kt
+++ b/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/PlexConnectionCardState.kt
@@ -1,0 +1,8 @@
+package com.cleverferret.v2.feature.plex.services.plex
+
+import com.cleverferret.v2.core.ui.components.ActionCard
+
+data class PlexConnectionCardState(
+    val accountCard: ActionCard,
+    val serverCard: ActionCard,
+)

--- a/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/PlexMetadataSyncService.kt
+++ b/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/PlexMetadataSyncService.kt
@@ -1,0 +1,53 @@
+package com.cleverferret.v2.feature.plex.services.plex
+
+import com.cleverferret.v2.core.common.result.IntegrationResult
+import com.cleverferret.v2.core.network.plex.PlexMetadataBoundary
+
+interface PlexSyncCheckpointStore {
+    fun read(): String?
+    fun write(checkpoint: String)
+    fun clear()
+}
+
+class InMemoryPlexSyncCheckpointStore : PlexSyncCheckpointStore {
+    private var checkpoint: String? = null
+    override fun read(): String? = checkpoint
+    override fun write(checkpoint: String) {
+        this.checkpoint = checkpoint
+    }
+    override fun clear() {
+        checkpoint = null
+    }
+}
+
+class PlexMetadataSyncService(
+    private val metadataBoundary: PlexMetadataBoundary,
+    private val checkpointStore: PlexSyncCheckpointStore,
+) {
+    fun clearCheckpoint() = checkpointStore.clear()
+
+    fun importMetadata(accessToken: String): IntegrationResult<PlexMetadataSyncOutcome> {
+        var cursor: String? = null
+        var imported = 0
+        var latestCheckpoint = checkpointStore.read().orEmpty()
+
+        do {
+            val pageResult = metadataBoundary.fetchMetadataPage(accessToken, cursor)
+            if (pageResult is IntegrationResult.Failure) {
+                return pageResult
+            }
+            val page = (pageResult as IntegrationResult.Success).value
+            imported += page.records.size
+            cursor = page.nextCursor
+            latestCheckpoint = page.syncCheckpoint
+        } while (cursor != null)
+
+        checkpointStore.write(latestCheckpoint)
+        return IntegrationResult.success(PlexMetadataSyncOutcome(imported, latestCheckpoint))
+    }
+}
+
+data class PlexMetadataSyncOutcome(
+    val importedItems: Int,
+    val checkpoint: String,
+)

--- a/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/PlexSyncResultV1.kt
+++ b/CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/PlexSyncResultV1.kt
@@ -4,5 +4,6 @@ package com.cleverferret.v2.feature.plex.services.plex
 data class PlexSyncResultV1(
     val accountId: String,
     val syncedItems: Int,
-    val syncedAtEpochMillis: Long
+    val syncedAtEpochMillis: Long,
+    val checkpoint: String,
 )

--- a/CleverFerretV2/feature/plex/src/test/java/com/cleverferret/v2/feature/plex/services/plex/PlexMetadataSyncServiceTest.kt
+++ b/CleverFerretV2/feature/plex/src/test/java/com/cleverferret/v2/feature/plex/services/plex/PlexMetadataSyncServiceTest.kt
@@ -1,0 +1,43 @@
+package com.cleverferret.v2.feature.plex.services.plex
+
+import com.cleverferret.v2.core.common.result.IntegrationResult
+import com.cleverferret.v2.core.network.plex.PlexMetadataBoundary
+import com.cleverferret.v2.core.network.plex.PlexMetadataPage
+import com.cleverferret.v2.core.network.plex.PlexMetadataRecord
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlexMetadataSyncServiceTest {
+    @Test
+    fun `initial import pages through records and stores checkpoint`() {
+        val checkpointStore = InMemoryPlexSyncCheckpointStore()
+        val boundary = object : PlexMetadataBoundary {
+            override fun fetchMetadataPage(accessToken: String, pageCursor: String?): IntegrationResult<PlexMetadataPage> {
+                return when (pageCursor) {
+                    null -> IntegrationResult.success(
+                        PlexMetadataPage(
+                            records = listOf(PlexMetadataRecord("1", "A", "movie", 1)),
+                            nextCursor = "page-2",
+                            syncCheckpoint = "cp-1",
+                        ),
+                    )
+                    "page-2" -> IntegrationResult.success(
+                        PlexMetadataPage(
+                            records = listOf(PlexMetadataRecord("2", "B", "show", 2), PlexMetadataRecord("3", "C", "show", 3)),
+                            nextCursor = null,
+                            syncCheckpoint = "cp-2",
+                        ),
+                    )
+                    else -> error("unexpected")
+                }
+            }
+        }
+
+        val service = PlexMetadataSyncService(boundary, checkpointStore)
+        val result = service.importMetadata("token") as IntegrationResult.Success
+
+        assertEquals(3, result.value.importedItems)
+        assertEquals("cp-2", result.value.checkpoint)
+        assertEquals("cp-2", checkpointStore.read())
+    }
+}


### PR DESCRIPTION
### Motivation
- Scope the work to an auth-first Plex milestone (issue #135): implement device/PIN link, token lifecycle (expiry + refresh/invalidation), and explicit sign-out that revokes local credentials and clears sensitive cache. 
- Provide clear integration boundaries so Plex SDK/client calls can be isolated and exercised from `core/auth` and `core/network` before expanding sync ingestion and UI polish. 
- Surface a minimal post-auth verification UI model (account + connection health) using the design system's `ActionCard` and semantic state colors. 
- Add a safe initial sync approach: one-way paginated import with an incremental checkpoint to enable subsequent pulls.

### Description
- Added `core/auth` primitives: `AuthTokens`, `DevicePinChallenge`, `AuthSessionManager` (handles device/PIN start+poll, expiry-aware access token retrieval, refresh handling, and `signOut`), `TokenStore`/`InMemoryTokenStore`, `TokenRefreshClient`, and tests for success/expiry/failure/sign-out flows. 
- Added `core/network` Plex integration boundaries and executor: `PlexAuthBoundary` / `PlexMetadataBoundary`, `AuthenticatedPlexRequestExecutor` that retries once on authentication failures, and `TokenRedactor` to sanitize tokens from logs. Tests cover retry-on-expiry and redaction. 
- Implemented `feature/plex` wiring: `PlexFeatureApi` expansion, `DefaultPlexFeatureApi` implementing device link / poll / sign-out, post-auth `PlexConnectionCardState` using new `ActionCard`/`SemanticStateColor`, and `PlexMetadataSyncService` with paginated import and checkpoint persistence (in-memory checkpoint store). 
- UI/design system touchups: add `ActionCard` component and fix `ComponentCatalogV1` Kotlin declarations; updated module dependencies to expose `core:auth` / `core:network` where needed and added `kotlin("test")` test dependencies to relevant modules.

### Testing
- Added unit tests: `AuthSessionManagerTest` (auth success, expiry+refresh, refresh failure clearing credentials, sign-out clears cache), `AuthenticatedPlexRequestExecutorTest` (retry on mid-request expiry, token redaction), and `PlexMetadataSyncServiceTest` (paginated import + checkpoint stored). 
- Attempted to run the test suite with `./gradlew -p CleverFerretV2 :core:auth:test :core:network:test :feature:plex:test`, but execution was blocked by the environment Java runtime (openjdk 25); the project requires JDK 17–21 so tests did not run in this environment. 
- No automated tests failed in-repo because the CI/test run could not be executed due to the JDK mismatch; the added tests are included and ready to run once an appropriate JDK is provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4e6181fc483239ddea7cabd2fe5b0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added device PIN authentication flow for secure account linking
* Implemented automatic token refresh for uninterrupted session access
* Added sign-out capability with full session revocation and data clearing
* Introduced account connection status and health monitoring displays
* Enhanced metadata synchronization with checkpoint tracking for reliable library imports

## Tests
* Added comprehensive test coverage for authentication and metadata synchronization workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements an auth-first Plex integration milestone that establishes device/PIN authentication flow, token lifecycle management with expiry and refresh logic, and explicit sign-out capabilities. It introduces core authentication primitives (`AuthSessionManager`, `AuthTokens`, `DevicePinChallenge`) with token storage and refresh handling, network layer boundaries for Plex API integration with automatic retry-on-expiry and token redaction for security, and a metadata sync service supporting paginated imports with checkpointing. The feature layer wires these together through `DefaultPlexFeatureApi` which exposes device linking, sign-out, connection health cards using the new `ActionCard` component, and library sync operations. Comprehensive unit tests cover authentication flows, token refresh scenarios, request retry logic, and sync checkpointing.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/AuthModels.kt` |
| 2 | `CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/AuthContracts.kt` |
| 3 | `CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/InMemoryTokenStore.kt` |
| 4 | `CleverFerretV2/core/auth/src/main/java/com/cleverferret/v2/core/auth/AuthSessionManager.kt` |
| 5 | `CleverFerretV2/core/auth/src/test/java/com/cleverferret/v2/core/auth/AuthSessionManagerTest.kt` |
| 6 | `CleverFerretV2/core/network/src/main/java/com/cleverferret/v2/core/network/plex/PlexIntegrationBoundary.kt` |
| 7 | `CleverFerretV2/core/network/src/main/java/com/cleverferret/v2/core/network/plex/AuthenticatedPlexRequestExecutor.kt` |
| 8 | `CleverFerretV2/core/network/src/test/java/com/cleverferret/v2/core/network/plex/AuthenticatedPlexRequestExecutorTest.kt` |
| 9 | `CleverFerretV2/core/ui/src/main/java/com/cleverferret/v2/core/ui/components/ActionCard.kt` |
| 10 | `CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/PlexMetadataSyncService.kt` |
| 11 | `CleverFerretV2/feature/plex/src/test/java/com/cleverferret/v2/feature/plex/services/plex/PlexMetadataSyncServiceTest.kt` |
| 12 | `CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/PlexConnectionCardState.kt` |
| 13 | `CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/api/PlexFeatureApi.kt` |
| 14 | `CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/DefaultPlexFeatureApi.kt` |
| 15 | `CleverFerretV2/feature/plex/src/main/java/com/cleverferret/v2/feature/plex/services/plex/PlexSyncResultV1.kt` |
| 16 | `CleverFerretV2/core/ui/src/main/java/com/cleverferret/v2/core/ui/components/ComponentCatalogV1.kt` |
| 17 | `CleverFerretV2/core/auth/build.gradle.kts` |
| 18 | `CleverFerretV2/core/network/build.gradle.kts` |
| 19 | `CleverFerretV2/feature/plex/build.gradle.kts` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `CleverFerretV2/core/ui/src/main/java/com/cleverferret/v2/core/ui/components/ComponentCatalogV1.kt` | Refactoring Java-style code to Kotlin syntax in the ComponentCatalogV1 appears unrelated to the Plex authentication and sync implementation focus of this PR |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->