### PR TITLE
Harden compile gate: remove CI bypass flags and add canary acceptance criteria

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,7 @@ jobs:
         # Using --warning-mode all to show warnings without excessive info
         COMPILE_LOG="compile_output_${GITHUB_SHA::8}_${GITHUB_RUN_ATTEMPT}.txt"
         echo "COMPILE_LOG=$COMPILE_LOG" >> "$GITHUB_ENV"
-        ./gradlew compileDebugKotlin --continue --stacktrace --warning-mode all 2>&1 | tee "$COMPILE_LOG"
+        ./gradlew compileDebugKotlin --stacktrace --warning-mode all 2>&1 | tee "$COMPILE_LOG"
         exit_code=${PIPESTATUS[0]}
         
         # If compilation failed, show the last 200 lines which usually contain the errors
@@ -92,7 +92,6 @@ jobs:
         fi
         
         exit $exit_code
-      continue-on-error: true
       
     - name: Report compilation results
       if: always()

--- a/CleverFerret/build.gradle.kts
+++ b/CleverFerret/build.gradle.kts
@@ -116,7 +116,7 @@ android {
         applicationId = "com.universalmedialibrary"
         minSdk = 26  // Android 8.0+ for broad device compatibility
         targetSdk = 36  // Android 15 (latest)
-        versionCode = 66
+        versionCode = 68
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/docs/governance/ci-bypass-postmortem.md
+++ b/docs/governance/ci-bypass-postmortem.md
@@ -1,0 +1,47 @@
+# CI Bypass Postmortem: Compile Gate Weakness
+
+## Summary
+A CI bypass condition existed in `.github/workflows/main.yml` where the compile step allowed failure without immediately failing the gate.
+
+Two settings created the bypass behavior:
+- `continue-on-error: true` on the `Compile project` step.
+- `--continue` passed to `./gradlew compileDebugKotlin`.
+
+Together, these allowed the pipeline to continue after compile failures and weakened branch-protection confidence in compile-gate enforcement.
+
+## Remediation Implemented
+- Removed `continue-on-error: true` from the `Compile project` step.
+- Removed `--continue` from `compileDebugKotlin` invocation.
+- Kept existing compile diagnostics, error summaries, and artifact upload/reporting paths so failure visibility remains intact.
+
+## Canary PR Acceptance Criteria (Compile-Failure Merge Block)
+A dedicated canary pull request must intentionally introduce a deterministic compile failure and satisfy all criteria below.
+
+1. **Intentional compile failure is introduced**
+   - Canary PR includes a minimal change that always fails Kotlin compilation (e.g., unresolved symbol in a compiled source set).
+
+2. **`test` workflow job fails at compile gate**
+   - GitHub Actions run for the PR shows `Compile project` step failed.
+   - Job result is `failure` (not `neutral`, not `success`).
+
+3. **Failure diagnostics remain visible**
+   - `Compilation Errors (last 200 lines)` group is emitted in logs.
+   - `Error Summary` group is emitted in logs.
+   - Compile log artifact upload step still runs (`if: always()`) and attempts upload.
+
+4. **Downstream behavior remains consistent with current summary/reporting design**
+   - Reporting steps with `if: always()` still execute.
+   - Final gate step (`Fail workflow if compilation or tests failed`) reports failure.
+
+5. **Merge is blocked by required checks**
+   - PR cannot be merged while `test` check is failing.
+   - UI shows merge blocked due to failed required status check(s).
+
+6. **Recovery is proven**
+   - Reverting/fixing the intentional compile error in the same PR causes compile to pass and unblocks merge eligibility.
+
+## Evidence to Capture in the Canary PR
+- Link to failed workflow run.
+- Screenshot or copied status-check panel showing merge blocked.
+- Link to subsequent passing run after the compile error is fixed.
+- Short note confirming compile diagnostics and artifacts were still produced during the failing run.


### PR DESCRIPTION
### Motivation

- Prevent compile failures from being masked by CI bypass behavior so the `test` job and branch protection accurately reflect trunk health.
- Preserve existing compile diagnostics and artifact/reporting flows so failures remain visible and debuggable in CI logs.
- Provide an explicit canary PR acceptance policy to prove the compile gate blocks merges when compilation fails.

### Description

- Removed `--continue` from the `./gradlew compileDebugKotlin` invocation in `.github/workflows/main.yml` so Kotlin compilation stops on fatal errors.
- Removed `continue-on-error: true` from the `Compile project` step in `.github/workflows/main.yml` so compile failures now mark the step/job as failed.
- Left reporting and aggregation behavior intact, including the `Report compilation results` step, the `Upload compilation log artifact` step, and the final `Fail workflow if compilation or tests failed` gate.
- Added `docs/governance/ci-bypass-postmortem.md` documenting the root cause, the remediation, and explicit acceptance criteria for a canary PR that intentionally fails compilation and must be blocked from merge.

### Testing

- No automated unit/integration test suites were executed as part of this change; CI behavior will be validated by the canary PR described in the added document.
- Repository validations confirmed the workflow now runs `./gradlew compileDebugKotlin --stacktrace --warning-mode all` and that the `Compile project` step no longer uses `continue-on-error: true`, while the reporting and artifact upload steps remain present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5df845c6c832389ff9ffc002a439f)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR hardens the CI compile gate by removing two bypass mechanisms (`--continue` flag and `continue-on-error: true`) that previously allowed the workflow to proceed despite compilation failures. It also introduces a postmortem document that explains the root cause, the remediation steps, and defines explicit acceptance criteria for a canary PR that will validate the compile gate now properly blocks merges when compilation fails.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docs/governance/ci-bypass-postmortem.md` |
| 2 | `.github/workflows/main.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->