### PR TITLE
Add VM test dispatcher migration planning doc

### DIFF
--- a/CleverFerret/build.gradle.kts
+++ b/CleverFerret/build.gradle.kts
@@ -116,7 +116,7 @@ android {
         applicationId = "com.universalmedialibrary"
         minSdk = 26  // Android 8.0+ for broad device compatibility
         targetSdk = 36  // Android 15 (latest)
-        versionCode = 69
+        versionCode = 70
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/CleverFerret/docs/VM_TEST_DISPATCHER_MIGRATION_PLAN.md
+++ b/CleverFerret/docs/VM_TEST_DISPATCHER_MIGRATION_PLAN.md
@@ -1,0 +1,46 @@
+# VM Test Dispatcher Migration Plan
+
+## Goal
+Create a minimal, repeatable path for converting ViewModel unit tests to use a coroutine-main dispatcher rule and modern Flow testing, starting with one proof-of-wiring conversion.
+
+## Scope
+
+### 1) Version catalog update (`gradle/libs.versions.toml`)
+- Add/confirm version-catalog entries for Turbine (`app.cash.turbine:turbine`).
+- Ensure dependency alias is available for module test dependencies used by ViewModel JVM tests.
+- Keep existing coroutine test dependencies aligned with Turbine version compatibility.
+
+### 2) Shared test utility addition
+- Add new file:
+  - `CleverFerret/src/test/java/com/universalmedialibrary/testing/MainDispatcherRule.kt`
+- Provide a JUnit rule that swaps `Dispatchers.Main` with a test dispatcher for JVM tests and restores it after test execution.
+- Choose `StandardTestDispatcher` as default for deterministic scheduling, with constructor override for flexibility.
+
+### 3) One proof-of-wiring conversion (target VM test)
+- Convert one existing ViewModel test class to use the new dispatcher rule (example target: `MediaHomeViewModelTest`).
+- Replace ad-hoc coroutine-main setup/teardown with the shared rule.
+- Add at least one Turbine-based Flow assertion to validate test wiring and usage pattern.
+
+## Out of Scope
+- Bulk migration of all ViewModel tests in this change.
+- Refactoring production ViewModel logic unrelated to testability.
+- Converting instrumentation tests; this plan targets JVM unit tests only.
+
+## Deliverables
+1. Version catalog change for Turbine in `gradle/libs.versions.toml`.
+2. New reusable `MainDispatcherRule.kt` utility under `src/test/.../testing`.
+3. One converted VM unit test demonstrating:
+   - rule installation,
+   - coroutine test dispatcher usage,
+   - Turbine assertion pattern.
+
+## Acceptance Criteria
+- `testDebugUnitTest` executes successfully with the converted VM test included.
+- Converted test class serves as a copyable template for subsequent ViewModel test migrations.
+- No regression in existing unit test task wiring caused by dispatcher-rule introduction.
+
+## Suggested Implementation Sequence
+1. Update version catalog and module test dependencies.
+2. Add `MainDispatcherRule` utility.
+3. Convert `MediaHomeViewModelTest` (or equivalent) and run `testDebugUnitTest`.
+4. Document migration snippet in test class comments (optional) to ease follow-on conversions.


### PR DESCRIPTION
### Motivation
- Create a minimal, repeatable plan to migrate ViewModel JVM tests to a shared `MainDispatcherRule` and Turbine-based Flow testing with one proof-of-wiring conversion so subsequent migrations are straightforward. 

### Description
- Add `CleverFerret/docs/VM_TEST_DISPATCHER_MIGRATION_PLAN.md` which scopes the required `gradle/libs.versions.toml` change for `app.cash.turbine:turbine`, the new test utility path `CleverFerret/src/test/java/com/universalmedialibrary/testing/MainDispatcherRule.kt`, and a target proof-of-wiring conversion for `MediaHomeViewModelTest` with clear deliverables and acceptance criteria. 

### Testing
- Executed `git -C /workspace/CleverFerret status --short`, committed the planning file with `git -C /workspace/CleverFerret commit -m "Add VM test dispatcher migration planning doc"`, and inspected the file with `nl -ba CleverFerret/docs/VM_TEST_DISPATCHER_MIGRATION_PLAN.md`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5ec594bd483239428e2dd45e75aac)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a planning document that outlines a strategy for migrating ViewModel JVM tests to use a shared `MainDispatcherRule` and Turbine-based Flow testing. The document details the scope (version catalog updates for Turbine, a new test utility rule, and one proof-of-wiring conversion), deliverables, acceptance criteria, and implementation sequence to establish a repeatable migration pattern for subsequent test conversions.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerret/docs/VM_TEST_DISPATCHER_MIGRATION_PLAN.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->