### PR TITLE
Modernize V2 app navigation into maintainable UX catalog

### DIFF
--- a/CleverFerret/build.gradle.kts
+++ b/CleverFerret/build.gradle.kts
@@ -116,7 +116,7 @@ android {
         applicationId = "com.universalmedialibrary"
         minSdk = 26  // Android 8.0+ for broad device compatibility
         targetSdk = 36  // Android 15 (latest)
-        versionCode = 80
+        versionCode = 81
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/CleverFerretV2/app/build.gradle.kts
+++ b/CleverFerretV2/app/build.gradle.kts
@@ -13,6 +13,7 @@ application {
 }
 
 dependencies {
+    testImplementation(kotlin("test"))
     implementation(project(":core:common"))
     implementation(project(":core:ui"))
     implementation(project(":core:data"))

--- a/CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/Main.kt
+++ b/CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/Main.kt
@@ -1,5 +1,7 @@
 package com.cleverferret.v2.app
 
+import com.cleverferret.v2.app.navigation.AppNavigationCatalog
+import com.cleverferret.v2.app.navigation.V2NavigationGraph
 import java.util.logging.Level
 import java.util.logging.Logger
 
@@ -7,4 +9,6 @@ private val logger: Logger = Logger.getLogger("CleverFerretV2")
 
 fun main() {
     logger.log(Level.INFO, "CleverFerretV2 composition root")
+    logger.log(Level.INFO, "Top-level domains: ${V2NavigationGraph.TopLevelDomain.entries.size}")
+    logger.log(Level.INFO, "Canonical routes: ${AppNavigationCatalog.allRoutes.size}")
 }

--- a/CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/AppDestination.kt
+++ b/CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/AppDestination.kt
@@ -1,0 +1,10 @@
+package com.cleverferret.v2.app.navigation
+
+/**
+ * Stable navigation destination contract used by all surfaces (phone/tablet/desktop/auto).
+ */
+data class AppDestination(
+    val route: String,
+    val title: String,
+    val supportsSearch: Boolean = false,
+)

--- a/CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/AppNavigationCatalog.kt
+++ b/CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/AppNavigationCatalog.kt
@@ -1,0 +1,65 @@
+package com.cleverferret.v2.app.navigation
+
+object AppNavigationCatalog {
+    private fun domain(
+        route: String,
+        title: String,
+        supportsSearch: Boolean = false,
+    ): AppDestination = AppDestination(route = route, title = title, supportsSearch = supportsSearch)
+
+    val topLevelDestinations: Map<V2NavigationGraph.TopLevelDomain, List<AppDestination>> = mapOf(
+        V2NavigationGraph.TopLevelDomain.LIBRARY to listOf(
+            domain("library/home", "Library", supportsSearch = true),
+            domain("library/item/{itemId}", "Item Details"),
+            domain("library/collection/{collectionId}", "Collection"),
+            domain("library/series/{seriesId}", "Series"),
+            domain("library/search", "Library Search", supportsSearch = true),
+        ),
+        V2NavigationGraph.TopLevelDomain.READER to listOf(
+            domain("reader/session/{itemId}", "Reader"),
+            domain("reader/contents/{itemId}", "Contents"),
+            domain("reader/annotations/{itemId}", "Annotations"),
+            domain("reader/theme", "Theme"),
+        ),
+        V2NavigationGraph.TopLevelDomain.AUDIO to listOf(
+            domain("audio/home", "Audio", supportsSearch = true),
+            domain("audio/now-playing", "Now Playing"),
+            domain("audio/queue", "Queue"),
+            domain("audio/audiobooks", "Audiobooks", supportsSearch = true),
+            domain("audio/podcasts", "Podcasts", supportsSearch = true),
+            domain("audio/music", "Music", supportsSearch = true),
+        ),
+        V2NavigationGraph.TopLevelDomain.RADIO to listOf(
+            domain("radio/home", "Radio", supportsSearch = true),
+            domain("radio/station/{stationId}", "Station"),
+            domain("radio/favorites", "Favorites"),
+        ),
+        V2NavigationGraph.TopLevelDomain.DISCOVER to listOf(
+            domain("discover/home", "Discover", supportsSearch = true),
+            domain("discover/search", "Discover Search", supportsSearch = true),
+            domain("discover/opds", "OPDS Catalogs"),
+            domain("discover/webfiction", "Web Fiction"),
+            domain("discover/recommendations", "Recommendations"),
+        ),
+        V2NavigationGraph.TopLevelDomain.SYNC to listOf(
+            domain("sync/home", "Sync"),
+            domain("sync/providers", "Providers"),
+            domain("sync/history", "History"),
+            domain("sync/conflicts", "Conflicts"),
+        ),
+        V2NavigationGraph.TopLevelDomain.SETTINGS to listOf(
+            domain("settings/home", "Settings", supportsSearch = true),
+            domain("settings/reader", "Reader Preferences"),
+            domain("settings/playback", "Playback Preferences"),
+            domain("settings/network", "Network Preferences"),
+            domain("settings/security", "Security"),
+            domain("settings/import-export", "Import and Export"),
+            domain("settings/about", "About"),
+        ),
+    )
+
+    val allRoutes: Set<String> = topLevelDestinations.values
+        .flatten()
+        .map { it.route }
+        .toSet()
+}

--- a/CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/V2NavigationGraph.kt
+++ b/CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/V2NavigationGraph.kt
@@ -1,17 +1,16 @@
 package com.cleverferret.v2.app.navigation
 
 object V2NavigationGraph {
-    enum class TopLevelDomain(val route: String) {
-        LIBRARY("library"), READER("reader"), AUDIO("audio"), RADIO("radio"), DISCOVER("discover"), SYNC("sync"), SETTINGS("settings")
+    enum class TopLevelDomain(val route: String, val displayName: String) {
+        LIBRARY("library", "Library"),
+        READER("reader", "Reader"),
+        AUDIO("audio", "Audio"),
+        RADIO("radio", "Radio"),
+        DISCOVER("discover", "Discover"),
+        SYNC("sync", "Sync"),
+        SETTINGS("settings", "Settings"),
     }
 
-    val CANONICAL_ROUTES = mapOf(
-        TopLevelDomain.LIBRARY to listOf("library/home", "library/item/{itemId}", "library/collection/{collectionId}", "library/series/{seriesId}", "library/search"),
-        TopLevelDomain.READER to listOf("reader/session/{itemId}", "reader/contents/{itemId}", "reader/annotations/{itemId}", "reader/theme"),
-        TopLevelDomain.AUDIO to listOf("audio/home", "audio/now-playing", "audio/queue", "audio/audiobooks", "audio/podcasts", "audio/music"),
-        TopLevelDomain.RADIO to listOf("radio/home", "radio/station/{stationId}", "radio/favorites"),
-        TopLevelDomain.DISCOVER to listOf("discover/home", "discover/search", "discover/opds", "discover/webfiction", "discover/recommendations"),
-        TopLevelDomain.SYNC to listOf("sync/home", "sync/providers", "sync/history", "sync/conflicts"),
-        TopLevelDomain.SETTINGS to listOf("settings/home", "settings/reader", "settings/playback", "settings/network", "settings/security", "settings/import-export", "settings/about")
-    )
+    val CANONICAL_ROUTES: Map<TopLevelDomain, List<String>> = AppNavigationCatalog.topLevelDestinations
+        .mapValues { (_, destinations) -> destinations.map(AppDestination::route) }
 }

--- a/CleverFerretV2/app/src/test/java/com/cleverferret/v2/app/navigation/AppNavigationCatalogTest.kt
+++ b/CleverFerretV2/app/src/test/java/com/cleverferret/v2/app/navigation/AppNavigationCatalogTest.kt
@@ -1,0 +1,21 @@
+package com.cleverferret.v2.app.navigation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AppNavigationCatalogTest {
+    @Test
+    fun `canonical routes are unique across the app`() {
+        val flattenedRoutes = AppNavigationCatalog.topLevelDestinations.values.flatten().map(AppDestination::route)
+
+        assertEquals(flattenedRoutes.size, flattenedRoutes.distinct().size)
+    }
+
+    @Test
+    fun `every top-level domain has at least one destination`() {
+        V2NavigationGraph.TopLevelDomain.entries.forEach { domain ->
+            assertTrue(AppNavigationCatalog.topLevelDestinations[domain].orEmpty().isNotEmpty())
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce brittle, duplicated route strings and centralize navigation metadata so multiple UI surfaces can share a single, testable contract.
- Prepare the V2 codebase for incremental UI/UX modernization by making route/title/search ownership explicit and easier to evolve.

### Description
- Added a stable navigation model `AppDestination` at `CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/AppDestination.kt` to hold `route`, `title`, and `supportsSearch`.
- Introduced `AppNavigationCatalog` at `CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/AppNavigationCatalog.kt` as the single source of truth for top-level domain destinations and route metadata.
- Refactored `V2NavigationGraph` to derive `CANONICAL_ROUTES` from the new catalog and added `displayName` to `TopLevelDomain` to improve UX labeling (`CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/V2NavigationGraph.kt`).
- Updated the composition root logging in `Main` to report domain and route coverage and wired app test dependency by adding `testImplementation(kotlin("test"))` to `CleverFerretV2/app/build.gradle.kts`.
- Added unit tests `AppNavigationCatalogTest` at `CleverFerretV2/app/src/test/java/com/cleverferret/v2/app/navigation/AppNavigationCatalogTest.kt` to assert route uniqueness and that each top-level domain has destinations.

### Testing
- Added automated unit tests (`AppNavigationCatalogTest`) but did not complete test execution because running `./gradlew -p CleverFerretV2 :app:test --no-daemon` failed during buildscript compilation.
- The test run failure is due to a pre-existing Gradle Kotlin DSL configuration error in `CleverFerretV2/build.gradle.kts` (script compilation errors such as `Expression 'java' cannot be invoked as a function`), which is unrelated to these navigation changes; no test suite was able to complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2e7cf1748323b0044f2a527fc4de)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the V2 app navigation system by introducing a centralized navigation catalog that eliminates duplicated route strings and provides a single source of truth for app destinations. The changes introduce `AppDestination` as a stable contract containing route, title, and search support metadata, and `AppNavigationCatalog` which maps all top-level domains to their destinations. The existing `V2NavigationGraph` now derives its canonical routes from this catalog, and a `displayName` field was added to improve UX labeling. Unit tests were added to validate route uniqueness and domain coverage, and the build configuration was updated to support testing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/AppDestination.kt` |
| 2 | `CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/AppNavigationCatalog.kt` |
| 3 | `CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/navigation/V2NavigationGraph.kt` |
| 4 | `CleverFerretV2/app/src/test/java/com/cleverferret/v2/app/navigation/AppNavigationCatalogTest.kt` |
| 5 | `CleverFerretV2/app/build.gradle.kts` |
| 6 | `CleverFerretV2/app/src/main/java/com/cleverferret/v2/app/Main.kt` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version code to 81.
  * Added Kotlin test framework support to build configuration.

* **Tests**
  * Added new test coverage to verify navigation route uniqueness and completeness across all application domains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->